### PR TITLE
Fix bug in faster_rcnn and remove redundant code in rfcn

### DIFF
--- a/faster_rcnn/test.py
+++ b/faster_rcnn/test.py
@@ -8,6 +8,7 @@
 										  
 import _init_paths
 
+import cv2
 import argparse
 import os
 import sys

--- a/faster_rcnn/train_end2end.py
+++ b/faster_rcnn/train_end2end.py
@@ -7,6 +7,7 @@
 # --------------------------------------------------------														  
 import _init_paths
 
+import cv2
 import time
 import argparse
 import logging

--- a/faster_rcnn/train_rcnn.py
+++ b/faster_rcnn/train_rcnn.py
@@ -8,6 +8,7 @@
 											  
 import _init_paths
 
+import cv2
 import time
 import argparse
 import logging

--- a/rfcn/train_end2end.py
+++ b/rfcn/train_end2end.py
@@ -84,9 +84,6 @@ def train_net(args, ctx, pretrained, epoch, prefix, begin_epoch, end_epoch, lr, 
     max_data_shape = [('data', (config.TRAIN.BATCH_IMAGES, 3, max([v[0] for v in config.SCALES]), max([v[1] for v in config.SCALES])))]
     max_data_shape, max_label_shape = train_data.infer_shape(max_data_shape)
     max_data_shape.append(('gt_boxes', (config.TRAIN.BATCH_IMAGES, 100, 5)))
-    max_data_shape = [('data', (config.TRAIN.BATCH_IMAGES, 3, max([v[0] for v in config.SCALES]), max([v[1] for v in config.SCALES])))]
-    max_data_shape, max_label_shape = train_data.infer_shape(max_data_shape)
-    max_data_shape.append(('gt_boxes', (config.TRAIN.BATCH_IMAGES, 100, 5)))
     print('providing maximum shape', max_data_shape, max_label_shape)
 
     data_shape_dict = dict(train_data.provide_data_single + train_data.provide_label_single)


### PR DESCRIPTION
add import cv2 in faster rcnn to avoid "Segmentation Fault"
remove redundant code in rfcn