### PR TITLE
Added symbol for Dense Faster R-CNN model

### DIFF
--- a/faster_rcnn/symbols/resnet_v1_101_rcnn_dcn_dense.py
+++ b/faster_rcnn/symbols/resnet_v1_101_rcnn_dcn_dense.py
@@ -1,0 +1,1186 @@
+# --------------------------------------------------------
+# Deformable Convolutional Networks
+# Copyright (c) 2017 Microsoft
+# Licensed under The Apache-2.0 License [see LICENSE for details]
+# Written by Guodong Zhang
+# --------------------------------------------------------
+
+import cPickle
+import mxnet as mx
+from utils.symbol import Symbol
+from operator_py.proposal import *
+from operator_py.proposal_target import *
+from operator_py.box_annotator_ohem import *
+
+
+class resnet_v1_101_rcnn_dcn_dense(Symbol):
+    def __init__(self):
+        """
+        Use __init__ to define parameter network needs
+        """
+        self.eps = 1e-5
+        self.use_global_stats = True
+        self.workspace = 512
+        self.units = (3, 4, 23, 3)  # use for 101
+        self.filter_list = [256, 512, 1024, 2048]
+
+    def get_resnet_v1_conv4(self, data):
+        conv1 = mx.symbol.Convolution(name='conv1', data=data, num_filter=64, pad=(3, 3), kernel=(7, 7), stride=(2, 2),
+                                      no_bias=True)
+        bn_conv1 = mx.symbol.BatchNorm(name='bn_conv1', data=conv1, use_global_stats=True, fix_gamma=False,
+                                       eps=self.eps)
+        scale_conv1 = bn_conv1
+        conv1_relu = mx.symbol.Activation(name='conv1_relu', data=scale_conv1, act_type='relu')
+        pool1 = mx.symbol.Pooling(name='pool1', data=conv1_relu, pooling_convention='full', pad=(0, 0), kernel=(3, 3),
+                                  stride=(2, 2), pool_type='max')
+        res2a_branch1 = mx.symbol.Convolution(name='res2a_branch1', data=pool1, num_filter=256, pad=(0, 0),
+                                              kernel=(1, 1),
+                                              stride=(1, 1), no_bias=True)
+        bn2a_branch1 = mx.symbol.BatchNorm(name='bn2a_branch1', data=res2a_branch1, use_global_stats=True,
+                                           fix_gamma=False, eps=self.eps)
+        scale2a_branch1 = bn2a_branch1
+        res2a_branch2a = mx.symbol.Convolution(name='res2a_branch2a', data=pool1, num_filter=64, pad=(0, 0),
+                                               kernel=(1, 1),
+                                               stride=(1, 1), no_bias=True)
+        bn2a_branch2a = mx.symbol.BatchNorm(name='bn2a_branch2a', data=res2a_branch2a, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale2a_branch2a = bn2a_branch2a
+        res2a_branch2a_relu = mx.symbol.Activation(name='res2a_branch2a_relu', data=scale2a_branch2a, act_type='relu')
+        res2a_branch2b = mx.symbol.Convolution(name='res2a_branch2b', data=res2a_branch2a_relu, num_filter=64,
+                                               pad=(1, 1),
+                                               kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn2a_branch2b = mx.symbol.BatchNorm(name='bn2a_branch2b', data=res2a_branch2b, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale2a_branch2b = bn2a_branch2b
+        res2a_branch2b_relu = mx.symbol.Activation(name='res2a_branch2b_relu', data=scale2a_branch2b, act_type='relu')
+        res2a_branch2c = mx.symbol.Convolution(name='res2a_branch2c', data=res2a_branch2b_relu, num_filter=256,
+                                               pad=(0, 0),
+                                               kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn2a_branch2c = mx.symbol.BatchNorm(name='bn2a_branch2c', data=res2a_branch2c, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale2a_branch2c = bn2a_branch2c
+        res2a = mx.symbol.broadcast_add(name='res2a', *[scale2a_branch1, scale2a_branch2c])
+        res2a_relu = mx.symbol.Activation(name='res2a_relu', data=res2a, act_type='relu')
+        res2b_branch2a = mx.symbol.Convolution(name='res2b_branch2a', data=res2a_relu, num_filter=64, pad=(0, 0),
+                                               kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn2b_branch2a = mx.symbol.BatchNorm(name='bn2b_branch2a', data=res2b_branch2a, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale2b_branch2a = bn2b_branch2a
+        res2b_branch2a_relu = mx.symbol.Activation(name='res2b_branch2a_relu', data=scale2b_branch2a, act_type='relu')
+        res2b_branch2b = mx.symbol.Convolution(name='res2b_branch2b', data=res2b_branch2a_relu, num_filter=64,
+                                               pad=(1, 1),
+                                               kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn2b_branch2b = mx.symbol.BatchNorm(name='bn2b_branch2b', data=res2b_branch2b, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale2b_branch2b = bn2b_branch2b
+        res2b_branch2b_relu = mx.symbol.Activation(name='res2b_branch2b_relu', data=scale2b_branch2b, act_type='relu')
+        res2b_branch2c = mx.symbol.Convolution(name='res2b_branch2c', data=res2b_branch2b_relu, num_filter=256,
+                                               pad=(0, 0),
+                                               kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn2b_branch2c = mx.symbol.BatchNorm(name='bn2b_branch2c', data=res2b_branch2c, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale2b_branch2c = bn2b_branch2c
+        res2b = mx.symbol.broadcast_add(name='res2b', *[res2a_relu, scale2b_branch2c])
+        res2b_relu = mx.symbol.Activation(name='res2b_relu', data=res2b, act_type='relu')
+        res2c_branch2a = mx.symbol.Convolution(name='res2c_branch2a', data=res2b_relu, num_filter=64, pad=(0, 0),
+                                               kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn2c_branch2a = mx.symbol.BatchNorm(name='bn2c_branch2a', data=res2c_branch2a, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale2c_branch2a = bn2c_branch2a
+        res2c_branch2a_relu = mx.symbol.Activation(name='res2c_branch2a_relu', data=scale2c_branch2a, act_type='relu')
+        res2c_branch2b = mx.symbol.Convolution(name='res2c_branch2b', data=res2c_branch2a_relu, num_filter=64,
+                                               pad=(1, 1),
+                                               kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn2c_branch2b = mx.symbol.BatchNorm(name='bn2c_branch2b', data=res2c_branch2b, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale2c_branch2b = bn2c_branch2b
+        res2c_branch2b_relu = mx.symbol.Activation(name='res2c_branch2b_relu', data=scale2c_branch2b, act_type='relu')
+        res2c_branch2c = mx.symbol.Convolution(name='res2c_branch2c', data=res2c_branch2b_relu, num_filter=256,
+                                               pad=(0, 0),
+                                               kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn2c_branch2c = mx.symbol.BatchNorm(name='bn2c_branch2c', data=res2c_branch2c, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale2c_branch2c = bn2c_branch2c
+        res2c = mx.symbol.broadcast_add(name='res2c', *[res2b_relu, scale2c_branch2c])
+        res2c_relu = mx.symbol.Activation(name='res2c_relu', data=res2c, act_type='relu')
+        res3a_branch1 = mx.symbol.Convolution(name='res3a_branch1', data=res2c_relu, num_filter=512, pad=(0, 0),
+                                              kernel=(1, 1), stride=(2, 2), no_bias=True)
+        bn3a_branch1 = mx.symbol.BatchNorm(name='bn3a_branch1', data=res3a_branch1, use_global_stats=True,
+                                           fix_gamma=False, eps=self.eps)
+        scale3a_branch1 = bn3a_branch1
+        res3a_branch2a = mx.symbol.Convolution(name='res3a_branch2a', data=res2c_relu, num_filter=128, pad=(0, 0),
+                                               kernel=(1, 1), stride=(2, 2), no_bias=True)
+        bn3a_branch2a = mx.symbol.BatchNorm(name='bn3a_branch2a', data=res3a_branch2a, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale3a_branch2a = bn3a_branch2a
+        res3a_branch2a_relu = mx.symbol.Activation(name='res3a_branch2a_relu', data=scale3a_branch2a, act_type='relu')
+        res3a_branch2b = mx.symbol.Convolution(name='res3a_branch2b', data=res3a_branch2a_relu, num_filter=128,
+                                               pad=(1, 1),
+                                               kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn3a_branch2b = mx.symbol.BatchNorm(name='bn3a_branch2b', data=res3a_branch2b, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale3a_branch2b = bn3a_branch2b
+        res3a_branch2b_relu = mx.symbol.Activation(name='res3a_branch2b_relu', data=scale3a_branch2b, act_type='relu')
+        res3a_branch2c = mx.symbol.Convolution(name='res3a_branch2c', data=res3a_branch2b_relu, num_filter=512,
+                                               pad=(0, 0),
+                                               kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn3a_branch2c = mx.symbol.BatchNorm(name='bn3a_branch2c', data=res3a_branch2c, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale3a_branch2c = bn3a_branch2c
+        res3a = mx.symbol.broadcast_add(name='res3a', *[scale3a_branch1, scale3a_branch2c])
+        res3a_relu = mx.symbol.Activation(name='res3a_relu', data=res3a, act_type='relu')
+        res3b1_branch2a = mx.symbol.Convolution(name='res3b1_branch2a', data=res3a_relu, num_filter=128, pad=(0, 0),
+                                                kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn3b1_branch2a = mx.symbol.BatchNorm(name='bn3b1_branch2a', data=res3b1_branch2a, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale3b1_branch2a = bn3b1_branch2a
+        res3b1_branch2a_relu = mx.symbol.Activation(name='res3b1_branch2a_relu', data=scale3b1_branch2a,
+                                                    act_type='relu')
+        res3b1_branch2b = mx.symbol.Convolution(name='res3b1_branch2b', data=res3b1_branch2a_relu, num_filter=128,
+                                                pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn3b1_branch2b = mx.symbol.BatchNorm(name='bn3b1_branch2b', data=res3b1_branch2b, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale3b1_branch2b = bn3b1_branch2b
+        res3b1_branch2b_relu = mx.symbol.Activation(name='res3b1_branch2b_relu', data=scale3b1_branch2b,
+                                                    act_type='relu')
+        res3b1_branch2c = mx.symbol.Convolution(name='res3b1_branch2c', data=res3b1_branch2b_relu, num_filter=512,
+                                                pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn3b1_branch2c = mx.symbol.BatchNorm(name='bn3b1_branch2c', data=res3b1_branch2c, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale3b1_branch2c = bn3b1_branch2c
+        res3b1 = mx.symbol.broadcast_add(name='res3b1', *[res3a_relu, scale3b1_branch2c])
+        res3b1_relu = mx.symbol.Activation(name='res3b1_relu', data=res3b1, act_type='relu')
+        res3b2_branch2a = mx.symbol.Convolution(name='res3b2_branch2a', data=res3b1_relu, num_filter=128, pad=(0, 0),
+                                                kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn3b2_branch2a = mx.symbol.BatchNorm(name='bn3b2_branch2a', data=res3b2_branch2a, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale3b2_branch2a = bn3b2_branch2a
+        res3b2_branch2a_relu = mx.symbol.Activation(name='res3b2_branch2a_relu', data=scale3b2_branch2a,
+                                                    act_type='relu')
+        res3b2_branch2b = mx.symbol.Convolution(name='res3b2_branch2b', data=res3b2_branch2a_relu, num_filter=128,
+                                                pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn3b2_branch2b = mx.symbol.BatchNorm(name='bn3b2_branch2b', data=res3b2_branch2b, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale3b2_branch2b = bn3b2_branch2b
+        res3b2_branch2b_relu = mx.symbol.Activation(name='res3b2_branch2b_relu', data=scale3b2_branch2b,
+                                                    act_type='relu')
+        res3b2_branch2c = mx.symbol.Convolution(name='res3b2_branch2c', data=res3b2_branch2b_relu, num_filter=512,
+                                                pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn3b2_branch2c = mx.symbol.BatchNorm(name='bn3b2_branch2c', data=res3b2_branch2c, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale3b2_branch2c = bn3b2_branch2c
+        res3b2 = mx.symbol.broadcast_add(name='res3b2', *[res3b1_relu, scale3b2_branch2c])
+        res3b2_relu = mx.symbol.Activation(name='res3b2_relu', data=res3b2, act_type='relu')
+        res3b3_branch2a = mx.symbol.Convolution(name='res3b3_branch2a', data=res3b2_relu, num_filter=128, pad=(0, 0),
+                                                kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn3b3_branch2a = mx.symbol.BatchNorm(name='bn3b3_branch2a', data=res3b3_branch2a, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale3b3_branch2a = bn3b3_branch2a
+        res3b3_branch2a_relu = mx.symbol.Activation(name='res3b3_branch2a_relu', data=scale3b3_branch2a,
+                                                    act_type='relu')
+        res3b3_branch2b = mx.symbol.Convolution(name='res3b3_branch2b', data=res3b3_branch2a_relu, num_filter=128,
+                                                pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn3b3_branch2b = mx.symbol.BatchNorm(name='bn3b3_branch2b', data=res3b3_branch2b, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale3b3_branch2b = bn3b3_branch2b
+        res3b3_branch2b_relu = mx.symbol.Activation(name='res3b3_branch2b_relu', data=scale3b3_branch2b,
+                                                    act_type='relu')
+        res3b3_branch2c = mx.symbol.Convolution(name='res3b3_branch2c', data=res3b3_branch2b_relu, num_filter=512,
+                                                pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn3b3_branch2c = mx.symbol.BatchNorm(name='bn3b3_branch2c', data=res3b3_branch2c, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale3b3_branch2c = bn3b3_branch2c
+        res3b3 = mx.symbol.broadcast_add(name='res3b3', *[res3b2_relu, scale3b3_branch2c])
+        res3b3_relu = mx.symbol.Activation(name='res3b3_relu', data=res3b3, act_type='relu')
+        res4a_branch1 = mx.symbol.Convolution(name='res4a_branch1', data=res3b3_relu, num_filter=1024, pad=(0, 0),
+                                              kernel=(1, 1), stride=(2, 2), no_bias=True)
+        bn4a_branch1 = mx.symbol.BatchNorm(name='bn4a_branch1', data=res4a_branch1, use_global_stats=True,
+                                           fix_gamma=False, eps=self.eps)
+        scale4a_branch1 = bn4a_branch1
+        res4a_branch2a = mx.symbol.Convolution(name='res4a_branch2a', data=res3b3_relu, num_filter=256, pad=(0, 0),
+                                               kernel=(1, 1), stride=(2, 2), no_bias=True)
+        bn4a_branch2a = mx.symbol.BatchNorm(name='bn4a_branch2a', data=res4a_branch2a, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale4a_branch2a = bn4a_branch2a
+        res4a_branch2a_relu = mx.symbol.Activation(name='res4a_branch2a_relu', data=scale4a_branch2a, act_type='relu')
+        res4a_branch2b = mx.symbol.Convolution(name='res4a_branch2b', data=res4a_branch2a_relu, num_filter=256,
+                                               pad=(1, 1),
+                                               kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4a_branch2b = mx.symbol.BatchNorm(name='bn4a_branch2b', data=res4a_branch2b, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale4a_branch2b = bn4a_branch2b
+        res4a_branch2b_relu = mx.symbol.Activation(name='res4a_branch2b_relu', data=scale4a_branch2b, act_type='relu')
+        res4a_branch2c = mx.symbol.Convolution(name='res4a_branch2c', data=res4a_branch2b_relu, num_filter=1024,
+                                               pad=(0, 0),
+                                               kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4a_branch2c = mx.symbol.BatchNorm(name='bn4a_branch2c', data=res4a_branch2c, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale4a_branch2c = bn4a_branch2c
+        res4a = mx.symbol.broadcast_add(name='res4a', *[scale4a_branch1, scale4a_branch2c])
+        res4a_relu = mx.symbol.Activation(name='res4a_relu', data=res4a, act_type='relu')
+        res4b1_branch2a = mx.symbol.Convolution(name='res4b1_branch2a', data=res4a_relu, num_filter=256, pad=(0, 0),
+                                                kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b1_branch2a = mx.symbol.BatchNorm(name='bn4b1_branch2a', data=res4b1_branch2a, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b1_branch2a = bn4b1_branch2a
+        res4b1_branch2a_relu = mx.symbol.Activation(name='res4b1_branch2a_relu', data=scale4b1_branch2a,
+                                                    act_type='relu')
+        res4b1_branch2b = mx.symbol.Convolution(name='res4b1_branch2b', data=res4b1_branch2a_relu, num_filter=256,
+                                                pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b1_branch2b = mx.symbol.BatchNorm(name='bn4b1_branch2b', data=res4b1_branch2b, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b1_branch2b = bn4b1_branch2b
+        res4b1_branch2b_relu = mx.symbol.Activation(name='res4b1_branch2b_relu', data=scale4b1_branch2b,
+                                                    act_type='relu')
+        res4b1_branch2c = mx.symbol.Convolution(name='res4b1_branch2c', data=res4b1_branch2b_relu, num_filter=1024,
+                                                pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b1_branch2c = mx.symbol.BatchNorm(name='bn4b1_branch2c', data=res4b1_branch2c, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b1_branch2c = bn4b1_branch2c
+        res4b1 = mx.symbol.broadcast_add(name='res4b1', *[res4a_relu, scale4b1_branch2c])
+        res4b1_relu = mx.symbol.Activation(name='res4b1_relu', data=res4b1, act_type='relu')
+        res4b2_branch2a = mx.symbol.Convolution(name='res4b2_branch2a', data=res4b1_relu, num_filter=256, pad=(0, 0),
+                                                kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b2_branch2a = mx.symbol.BatchNorm(name='bn4b2_branch2a', data=res4b2_branch2a, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b2_branch2a = bn4b2_branch2a
+        res4b2_branch2a_relu = mx.symbol.Activation(name='res4b2_branch2a_relu', data=scale4b2_branch2a,
+                                                    act_type='relu')
+        res4b2_branch2b = mx.symbol.Convolution(name='res4b2_branch2b', data=res4b2_branch2a_relu, num_filter=256,
+                                                pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b2_branch2b = mx.symbol.BatchNorm(name='bn4b2_branch2b', data=res4b2_branch2b, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b2_branch2b = bn4b2_branch2b
+        res4b2_branch2b_relu = mx.symbol.Activation(name='res4b2_branch2b_relu', data=scale4b2_branch2b,
+                                                    act_type='relu')
+        res4b2_branch2c = mx.symbol.Convolution(name='res4b2_branch2c', data=res4b2_branch2b_relu, num_filter=1024,
+                                                pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b2_branch2c = mx.symbol.BatchNorm(name='bn4b2_branch2c', data=res4b2_branch2c, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b2_branch2c = bn4b2_branch2c
+        res4b2 = mx.symbol.broadcast_add(name='res4b2', *[res4b1_relu, scale4b2_branch2c])
+        res4b2_relu = mx.symbol.Activation(name='res4b2_relu', data=res4b2, act_type='relu')
+        res4b3_branch2a = mx.symbol.Convolution(name='res4b3_branch2a', data=res4b2_relu, num_filter=256, pad=(0, 0),
+                                                kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b3_branch2a = mx.symbol.BatchNorm(name='bn4b3_branch2a', data=res4b3_branch2a, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b3_branch2a = bn4b3_branch2a
+        res4b3_branch2a_relu = mx.symbol.Activation(name='res4b3_branch2a_relu', data=scale4b3_branch2a,
+                                                    act_type='relu')
+        res4b3_branch2b = mx.symbol.Convolution(name='res4b3_branch2b', data=res4b3_branch2a_relu, num_filter=256,
+                                                pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b3_branch2b = mx.symbol.BatchNorm(name='bn4b3_branch2b', data=res4b3_branch2b, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b3_branch2b = bn4b3_branch2b
+        res4b3_branch2b_relu = mx.symbol.Activation(name='res4b3_branch2b_relu', data=scale4b3_branch2b,
+                                                    act_type='relu')
+        res4b3_branch2c = mx.symbol.Convolution(name='res4b3_branch2c', data=res4b3_branch2b_relu, num_filter=1024,
+                                                pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b3_branch2c = mx.symbol.BatchNorm(name='bn4b3_branch2c', data=res4b3_branch2c, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b3_branch2c = bn4b3_branch2c
+        res4b3 = mx.symbol.broadcast_add(name='res4b3', *[res4b2_relu, scale4b3_branch2c])
+        res4b3_relu = mx.symbol.Activation(name='res4b3_relu', data=res4b3, act_type='relu')
+        res4b4_branch2a = mx.symbol.Convolution(name='res4b4_branch2a', data=res4b3_relu, num_filter=256, pad=(0, 0),
+                                                kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b4_branch2a = mx.symbol.BatchNorm(name='bn4b4_branch2a', data=res4b4_branch2a, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b4_branch2a = bn4b4_branch2a
+        res4b4_branch2a_relu = mx.symbol.Activation(name='res4b4_branch2a_relu', data=scale4b4_branch2a,
+                                                    act_type='relu')
+        res4b4_branch2b = mx.symbol.Convolution(name='res4b4_branch2b', data=res4b4_branch2a_relu, num_filter=256,
+                                                pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b4_branch2b = mx.symbol.BatchNorm(name='bn4b4_branch2b', data=res4b4_branch2b, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b4_branch2b = bn4b4_branch2b
+        res4b4_branch2b_relu = mx.symbol.Activation(name='res4b4_branch2b_relu', data=scale4b4_branch2b,
+                                                    act_type='relu')
+        res4b4_branch2c = mx.symbol.Convolution(name='res4b4_branch2c', data=res4b4_branch2b_relu, num_filter=1024,
+                                                pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b4_branch2c = mx.symbol.BatchNorm(name='bn4b4_branch2c', data=res4b4_branch2c, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b4_branch2c = bn4b4_branch2c
+        res4b4 = mx.symbol.broadcast_add(name='res4b4', *[res4b3_relu, scale4b4_branch2c])
+        res4b4_relu = mx.symbol.Activation(name='res4b4_relu', data=res4b4, act_type='relu')
+        res4b5_branch2a = mx.symbol.Convolution(name='res4b5_branch2a', data=res4b4_relu, num_filter=256, pad=(0, 0),
+                                                kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b5_branch2a = mx.symbol.BatchNorm(name='bn4b5_branch2a', data=res4b5_branch2a, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b5_branch2a = bn4b5_branch2a
+        res4b5_branch2a_relu = mx.symbol.Activation(name='res4b5_branch2a_relu', data=scale4b5_branch2a,
+                                                    act_type='relu')
+        res4b5_branch2b = mx.symbol.Convolution(name='res4b5_branch2b', data=res4b5_branch2a_relu, num_filter=256,
+                                                pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b5_branch2b = mx.symbol.BatchNorm(name='bn4b5_branch2b', data=res4b5_branch2b, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b5_branch2b = bn4b5_branch2b
+        res4b5_branch2b_relu = mx.symbol.Activation(name='res4b5_branch2b_relu', data=scale4b5_branch2b,
+                                                    act_type='relu')
+        res4b5_branch2c = mx.symbol.Convolution(name='res4b5_branch2c', data=res4b5_branch2b_relu, num_filter=1024,
+                                                pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b5_branch2c = mx.symbol.BatchNorm(name='bn4b5_branch2c', data=res4b5_branch2c, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b5_branch2c = bn4b5_branch2c
+        res4b5 = mx.symbol.broadcast_add(name='res4b5', *[res4b4_relu, scale4b5_branch2c])
+        res4b5_relu = mx.symbol.Activation(name='res4b5_relu', data=res4b5, act_type='relu')
+        res4b6_branch2a = mx.symbol.Convolution(name='res4b6_branch2a', data=res4b5_relu, num_filter=256, pad=(0, 0),
+                                                kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b6_branch2a = mx.symbol.BatchNorm(name='bn4b6_branch2a', data=res4b6_branch2a, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b6_branch2a = bn4b6_branch2a
+        res4b6_branch2a_relu = mx.symbol.Activation(name='res4b6_branch2a_relu', data=scale4b6_branch2a,
+                                                    act_type='relu')
+        res4b6_branch2b = mx.symbol.Convolution(name='res4b6_branch2b', data=res4b6_branch2a_relu, num_filter=256,
+                                                pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b6_branch2b = mx.symbol.BatchNorm(name='bn4b6_branch2b', data=res4b6_branch2b, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b6_branch2b = bn4b6_branch2b
+        res4b6_branch2b_relu = mx.symbol.Activation(name='res4b6_branch2b_relu', data=scale4b6_branch2b,
+                                                    act_type='relu')
+        res4b6_branch2c = mx.symbol.Convolution(name='res4b6_branch2c', data=res4b6_branch2b_relu, num_filter=1024,
+                                                pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b6_branch2c = mx.symbol.BatchNorm(name='bn4b6_branch2c', data=res4b6_branch2c, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b6_branch2c = bn4b6_branch2c
+        res4b6 = mx.symbol.broadcast_add(name='res4b6', *[res4b5_relu, scale4b6_branch2c])
+        res4b6_relu = mx.symbol.Activation(name='res4b6_relu', data=res4b6, act_type='relu')
+        res4b7_branch2a = mx.symbol.Convolution(name='res4b7_branch2a', data=res4b6_relu, num_filter=256, pad=(0, 0),
+                                                kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b7_branch2a = mx.symbol.BatchNorm(name='bn4b7_branch2a', data=res4b7_branch2a, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b7_branch2a = bn4b7_branch2a
+        res4b7_branch2a_relu = mx.symbol.Activation(name='res4b7_branch2a_relu', data=scale4b7_branch2a,
+                                                    act_type='relu')
+        res4b7_branch2b = mx.symbol.Convolution(name='res4b7_branch2b', data=res4b7_branch2a_relu, num_filter=256,
+                                                pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b7_branch2b = mx.symbol.BatchNorm(name='bn4b7_branch2b', data=res4b7_branch2b, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b7_branch2b = bn4b7_branch2b
+        res4b7_branch2b_relu = mx.symbol.Activation(name='res4b7_branch2b_relu', data=scale4b7_branch2b,
+                                                    act_type='relu')
+        res4b7_branch2c = mx.symbol.Convolution(name='res4b7_branch2c', data=res4b7_branch2b_relu, num_filter=1024,
+                                                pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b7_branch2c = mx.symbol.BatchNorm(name='bn4b7_branch2c', data=res4b7_branch2c, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b7_branch2c = bn4b7_branch2c
+        res4b7 = mx.symbol.broadcast_add(name='res4b7', *[res4b6_relu, scale4b7_branch2c])
+        res4b7_relu = mx.symbol.Activation(name='res4b7_relu', data=res4b7, act_type='relu')
+        res4b8_branch2a = mx.symbol.Convolution(name='res4b8_branch2a', data=res4b7_relu, num_filter=256, pad=(0, 0),
+                                                kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b8_branch2a = mx.symbol.BatchNorm(name='bn4b8_branch2a', data=res4b8_branch2a, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b8_branch2a = bn4b8_branch2a
+        res4b8_branch2a_relu = mx.symbol.Activation(name='res4b8_branch2a_relu', data=scale4b8_branch2a,
+                                                    act_type='relu')
+        res4b8_branch2b = mx.symbol.Convolution(name='res4b8_branch2b', data=res4b8_branch2a_relu, num_filter=256,
+                                                pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b8_branch2b = mx.symbol.BatchNorm(name='bn4b8_branch2b', data=res4b8_branch2b, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b8_branch2b = bn4b8_branch2b
+        res4b8_branch2b_relu = mx.symbol.Activation(name='res4b8_branch2b_relu', data=scale4b8_branch2b,
+                                                    act_type='relu')
+        res4b8_branch2c = mx.symbol.Convolution(name='res4b8_branch2c', data=res4b8_branch2b_relu, num_filter=1024,
+                                                pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b8_branch2c = mx.symbol.BatchNorm(name='bn4b8_branch2c', data=res4b8_branch2c, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b8_branch2c = bn4b8_branch2c
+        res4b8 = mx.symbol.broadcast_add(name='res4b8', *[res4b7_relu, scale4b8_branch2c])
+        res4b8_relu = mx.symbol.Activation(name='res4b8_relu', data=res4b8, act_type='relu')
+        res4b9_branch2a = mx.symbol.Convolution(name='res4b9_branch2a', data=res4b8_relu, num_filter=256, pad=(0, 0),
+                                                kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b9_branch2a = mx.symbol.BatchNorm(name='bn4b9_branch2a', data=res4b9_branch2a, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b9_branch2a = bn4b9_branch2a
+        res4b9_branch2a_relu = mx.symbol.Activation(name='res4b9_branch2a_relu', data=scale4b9_branch2a,
+                                                    act_type='relu')
+        res4b9_branch2b = mx.symbol.Convolution(name='res4b9_branch2b', data=res4b9_branch2a_relu, num_filter=256,
+                                                pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b9_branch2b = mx.symbol.BatchNorm(name='bn4b9_branch2b', data=res4b9_branch2b, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b9_branch2b = bn4b9_branch2b
+        res4b9_branch2b_relu = mx.symbol.Activation(name='res4b9_branch2b_relu', data=scale4b9_branch2b,
+                                                    act_type='relu')
+        res4b9_branch2c = mx.symbol.Convolution(name='res4b9_branch2c', data=res4b9_branch2b_relu, num_filter=1024,
+                                                pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b9_branch2c = mx.symbol.BatchNorm(name='bn4b9_branch2c', data=res4b9_branch2c, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b9_branch2c = bn4b9_branch2c
+        res4b9 = mx.symbol.broadcast_add(name='res4b9', *[res4b8_relu, scale4b9_branch2c])
+        res4b9_relu = mx.symbol.Activation(name='res4b9_relu', data=res4b9, act_type='relu')
+        res4b10_branch2a = mx.symbol.Convolution(name='res4b10_branch2a', data=res4b9_relu, num_filter=256, pad=(0, 0),
+                                                 kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b10_branch2a = mx.symbol.BatchNorm(name='bn4b10_branch2a', data=res4b10_branch2a, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b10_branch2a = bn4b10_branch2a
+        res4b10_branch2a_relu = mx.symbol.Activation(name='res4b10_branch2a_relu', data=scale4b10_branch2a,
+                                                     act_type='relu')
+        res4b10_branch2b = mx.symbol.Convolution(name='res4b10_branch2b', data=res4b10_branch2a_relu, num_filter=256,
+                                                 pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b10_branch2b = mx.symbol.BatchNorm(name='bn4b10_branch2b', data=res4b10_branch2b, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b10_branch2b = bn4b10_branch2b
+        res4b10_branch2b_relu = mx.symbol.Activation(name='res4b10_branch2b_relu', data=scale4b10_branch2b,
+                                                     act_type='relu')
+        res4b10_branch2c = mx.symbol.Convolution(name='res4b10_branch2c', data=res4b10_branch2b_relu, num_filter=1024,
+                                                 pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b10_branch2c = mx.symbol.BatchNorm(name='bn4b10_branch2c', data=res4b10_branch2c, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b10_branch2c = bn4b10_branch2c
+        res4b10 = mx.symbol.broadcast_add(name='res4b10', *[res4b9_relu, scale4b10_branch2c])
+        res4b10_relu = mx.symbol.Activation(name='res4b10_relu', data=res4b10, act_type='relu')
+        res4b11_branch2a = mx.symbol.Convolution(name='res4b11_branch2a', data=res4b10_relu, num_filter=256, pad=(0, 0),
+                                                 kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b11_branch2a = mx.symbol.BatchNorm(name='bn4b11_branch2a', data=res4b11_branch2a, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b11_branch2a = bn4b11_branch2a
+        res4b11_branch2a_relu = mx.symbol.Activation(name='res4b11_branch2a_relu', data=scale4b11_branch2a,
+                                                     act_type='relu')
+        res4b11_branch2b = mx.symbol.Convolution(name='res4b11_branch2b', data=res4b11_branch2a_relu, num_filter=256,
+                                                 pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b11_branch2b = mx.symbol.BatchNorm(name='bn4b11_branch2b', data=res4b11_branch2b, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b11_branch2b = bn4b11_branch2b
+        res4b11_branch2b_relu = mx.symbol.Activation(name='res4b11_branch2b_relu', data=scale4b11_branch2b,
+                                                     act_type='relu')
+        res4b11_branch2c = mx.symbol.Convolution(name='res4b11_branch2c', data=res4b11_branch2b_relu, num_filter=1024,
+                                                 pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b11_branch2c = mx.symbol.BatchNorm(name='bn4b11_branch2c', data=res4b11_branch2c, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b11_branch2c = bn4b11_branch2c
+        res4b11 = mx.symbol.broadcast_add(name='res4b11', *[res4b10_relu, scale4b11_branch2c])
+        res4b11_relu = mx.symbol.Activation(name='res4b11_relu', data=res4b11, act_type='relu')
+        res4b12_branch2a = mx.symbol.Convolution(name='res4b12_branch2a', data=res4b11_relu, num_filter=256, pad=(0, 0),
+                                                 kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b12_branch2a = mx.symbol.BatchNorm(name='bn4b12_branch2a', data=res4b12_branch2a, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b12_branch2a = bn4b12_branch2a
+        res4b12_branch2a_relu = mx.symbol.Activation(name='res4b12_branch2a_relu', data=scale4b12_branch2a,
+                                                     act_type='relu')
+        res4b12_branch2b = mx.symbol.Convolution(name='res4b12_branch2b', data=res4b12_branch2a_relu, num_filter=256,
+                                                 pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b12_branch2b = mx.symbol.BatchNorm(name='bn4b12_branch2b', data=res4b12_branch2b, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b12_branch2b = bn4b12_branch2b
+        res4b12_branch2b_relu = mx.symbol.Activation(name='res4b12_branch2b_relu', data=scale4b12_branch2b,
+                                                     act_type='relu')
+        res4b12_branch2c = mx.symbol.Convolution(name='res4b12_branch2c', data=res4b12_branch2b_relu, num_filter=1024,
+                                                 pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b12_branch2c = mx.symbol.BatchNorm(name='bn4b12_branch2c', data=res4b12_branch2c, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b12_branch2c = bn4b12_branch2c
+        res4b12 = mx.symbol.broadcast_add(name='res4b12', *[res4b11_relu, scale4b12_branch2c])
+        res4b12_relu = mx.symbol.Activation(name='res4b12_relu', data=res4b12, act_type='relu')
+        res4b13_branch2a = mx.symbol.Convolution(name='res4b13_branch2a', data=res4b12_relu, num_filter=256, pad=(0, 0),
+                                                 kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b13_branch2a = mx.symbol.BatchNorm(name='bn4b13_branch2a', data=res4b13_branch2a, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b13_branch2a = bn4b13_branch2a
+        res4b13_branch2a_relu = mx.symbol.Activation(name='res4b13_branch2a_relu', data=scale4b13_branch2a,
+                                                     act_type='relu')
+        res4b13_branch2b = mx.symbol.Convolution(name='res4b13_branch2b', data=res4b13_branch2a_relu, num_filter=256,
+                                                 pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b13_branch2b = mx.symbol.BatchNorm(name='bn4b13_branch2b', data=res4b13_branch2b, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b13_branch2b = bn4b13_branch2b
+        res4b13_branch2b_relu = mx.symbol.Activation(name='res4b13_branch2b_relu', data=scale4b13_branch2b,
+                                                     act_type='relu')
+        res4b13_branch2c = mx.symbol.Convolution(name='res4b13_branch2c', data=res4b13_branch2b_relu, num_filter=1024,
+                                                 pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b13_branch2c = mx.symbol.BatchNorm(name='bn4b13_branch2c', data=res4b13_branch2c, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b13_branch2c = bn4b13_branch2c
+        res4b13 = mx.symbol.broadcast_add(name='res4b13', *[res4b12_relu, scale4b13_branch2c])
+        res4b13_relu = mx.symbol.Activation(name='res4b13_relu', data=res4b13, act_type='relu')
+        res4b14_branch2a = mx.symbol.Convolution(name='res4b14_branch2a', data=res4b13_relu, num_filter=256, pad=(0, 0),
+                                                 kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b14_branch2a = mx.symbol.BatchNorm(name='bn4b14_branch2a', data=res4b14_branch2a, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b14_branch2a = bn4b14_branch2a
+        res4b14_branch2a_relu = mx.symbol.Activation(name='res4b14_branch2a_relu', data=scale4b14_branch2a,
+                                                     act_type='relu')
+        res4b14_branch2b = mx.symbol.Convolution(name='res4b14_branch2b', data=res4b14_branch2a_relu, num_filter=256,
+                                                 pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b14_branch2b = mx.symbol.BatchNorm(name='bn4b14_branch2b', data=res4b14_branch2b, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b14_branch2b = bn4b14_branch2b
+        res4b14_branch2b_relu = mx.symbol.Activation(name='res4b14_branch2b_relu', data=scale4b14_branch2b,
+                                                     act_type='relu')
+        res4b14_branch2c = mx.symbol.Convolution(name='res4b14_branch2c', data=res4b14_branch2b_relu, num_filter=1024,
+                                                 pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b14_branch2c = mx.symbol.BatchNorm(name='bn4b14_branch2c', data=res4b14_branch2c, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b14_branch2c = bn4b14_branch2c
+        res4b14 = mx.symbol.broadcast_add(name='res4b14', *[res4b13_relu, scale4b14_branch2c])
+        res4b14_relu = mx.symbol.Activation(name='res4b14_relu', data=res4b14, act_type='relu')
+        res4b15_branch2a = mx.symbol.Convolution(name='res4b15_branch2a', data=res4b14_relu, num_filter=256, pad=(0, 0),
+                                                 kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b15_branch2a = mx.symbol.BatchNorm(name='bn4b15_branch2a', data=res4b15_branch2a, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b15_branch2a = bn4b15_branch2a
+        res4b15_branch2a_relu = mx.symbol.Activation(name='res4b15_branch2a_relu', data=scale4b15_branch2a,
+                                                     act_type='relu')
+        res4b15_branch2b = mx.symbol.Convolution(name='res4b15_branch2b', data=res4b15_branch2a_relu, num_filter=256,
+                                                 pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b15_branch2b = mx.symbol.BatchNorm(name='bn4b15_branch2b', data=res4b15_branch2b, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b15_branch2b = bn4b15_branch2b
+        res4b15_branch2b_relu = mx.symbol.Activation(name='res4b15_branch2b_relu', data=scale4b15_branch2b,
+                                                     act_type='relu')
+        res4b15_branch2c = mx.symbol.Convolution(name='res4b15_branch2c', data=res4b15_branch2b_relu, num_filter=1024,
+                                                 pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b15_branch2c = mx.symbol.BatchNorm(name='bn4b15_branch2c', data=res4b15_branch2c, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b15_branch2c = bn4b15_branch2c
+        res4b15 = mx.symbol.broadcast_add(name='res4b15', *[res4b14_relu, scale4b15_branch2c])
+        res4b15_relu = mx.symbol.Activation(name='res4b15_relu', data=res4b15, act_type='relu')
+        res4b16_branch2a = mx.symbol.Convolution(name='res4b16_branch2a', data=res4b15_relu, num_filter=256, pad=(0, 0),
+                                                 kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b16_branch2a = mx.symbol.BatchNorm(name='bn4b16_branch2a', data=res4b16_branch2a, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b16_branch2a = bn4b16_branch2a
+        res4b16_branch2a_relu = mx.symbol.Activation(name='res4b16_branch2a_relu', data=scale4b16_branch2a,
+                                                     act_type='relu')
+        res4b16_branch2b = mx.symbol.Convolution(name='res4b16_branch2b', data=res4b16_branch2a_relu, num_filter=256,
+                                                 pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b16_branch2b = mx.symbol.BatchNorm(name='bn4b16_branch2b', data=res4b16_branch2b, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b16_branch2b = bn4b16_branch2b
+        res4b16_branch2b_relu = mx.symbol.Activation(name='res4b16_branch2b_relu', data=scale4b16_branch2b,
+                                                     act_type='relu')
+        res4b16_branch2c = mx.symbol.Convolution(name='res4b16_branch2c', data=res4b16_branch2b_relu, num_filter=1024,
+                                                 pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b16_branch2c = mx.symbol.BatchNorm(name='bn4b16_branch2c', data=res4b16_branch2c, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b16_branch2c = bn4b16_branch2c
+        res4b16 = mx.symbol.broadcast_add(name='res4b16', *[res4b15_relu, scale4b16_branch2c])
+        res4b16_relu = mx.symbol.Activation(name='res4b16_relu', data=res4b16, act_type='relu')
+        res4b17_branch2a = mx.symbol.Convolution(name='res4b17_branch2a', data=res4b16_relu, num_filter=256, pad=(0, 0),
+                                                 kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b17_branch2a = mx.symbol.BatchNorm(name='bn4b17_branch2a', data=res4b17_branch2a, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b17_branch2a = bn4b17_branch2a
+        res4b17_branch2a_relu = mx.symbol.Activation(name='res4b17_branch2a_relu', data=scale4b17_branch2a,
+                                                     act_type='relu')
+        res4b17_branch2b = mx.symbol.Convolution(name='res4b17_branch2b', data=res4b17_branch2a_relu, num_filter=256,
+                                                 pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b17_branch2b = mx.symbol.BatchNorm(name='bn4b17_branch2b', data=res4b17_branch2b, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b17_branch2b = bn4b17_branch2b
+        res4b17_branch2b_relu = mx.symbol.Activation(name='res4b17_branch2b_relu', data=scale4b17_branch2b,
+                                                     act_type='relu')
+        res4b17_branch2c = mx.symbol.Convolution(name='res4b17_branch2c', data=res4b17_branch2b_relu, num_filter=1024,
+                                                 pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b17_branch2c = mx.symbol.BatchNorm(name='bn4b17_branch2c', data=res4b17_branch2c, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b17_branch2c = bn4b17_branch2c
+        res4b17 = mx.symbol.broadcast_add(name='res4b17', *[res4b16_relu, scale4b17_branch2c])
+        res4b17_relu = mx.symbol.Activation(name='res4b17_relu', data=res4b17, act_type='relu')
+        res4b18_branch2a = mx.symbol.Convolution(name='res4b18_branch2a', data=res4b17_relu, num_filter=256, pad=(0, 0),
+                                                 kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b18_branch2a = mx.symbol.BatchNorm(name='bn4b18_branch2a', data=res4b18_branch2a, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b18_branch2a = bn4b18_branch2a
+        res4b18_branch2a_relu = mx.symbol.Activation(name='res4b18_branch2a_relu', data=scale4b18_branch2a,
+                                                     act_type='relu')
+        res4b18_branch2b = mx.symbol.Convolution(name='res4b18_branch2b', data=res4b18_branch2a_relu, num_filter=256,
+                                                 pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b18_branch2b = mx.symbol.BatchNorm(name='bn4b18_branch2b', data=res4b18_branch2b, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b18_branch2b = bn4b18_branch2b
+        res4b18_branch2b_relu = mx.symbol.Activation(name='res4b18_branch2b_relu', data=scale4b18_branch2b,
+                                                     act_type='relu')
+        res4b18_branch2c = mx.symbol.Convolution(name='res4b18_branch2c', data=res4b18_branch2b_relu, num_filter=1024,
+                                                 pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b18_branch2c = mx.symbol.BatchNorm(name='bn4b18_branch2c', data=res4b18_branch2c, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b18_branch2c = bn4b18_branch2c
+        res4b18 = mx.symbol.broadcast_add(name='res4b18', *[res4b17_relu, scale4b18_branch2c])
+        res4b18_relu = mx.symbol.Activation(name='res4b18_relu', data=res4b18, act_type='relu')
+        res4b19_branch2a = mx.symbol.Convolution(name='res4b19_branch2a', data=res4b18_relu, num_filter=256, pad=(0, 0),
+                                                 kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b19_branch2a = mx.symbol.BatchNorm(name='bn4b19_branch2a', data=res4b19_branch2a, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b19_branch2a = bn4b19_branch2a
+        res4b19_branch2a_relu = mx.symbol.Activation(name='res4b19_branch2a_relu', data=scale4b19_branch2a,
+                                                     act_type='relu')
+        res4b19_branch2b = mx.symbol.Convolution(name='res4b19_branch2b', data=res4b19_branch2a_relu, num_filter=256,
+                                                 pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b19_branch2b = mx.symbol.BatchNorm(name='bn4b19_branch2b', data=res4b19_branch2b, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b19_branch2b = bn4b19_branch2b
+        res4b19_branch2b_relu = mx.symbol.Activation(name='res4b19_branch2b_relu', data=scale4b19_branch2b,
+                                                     act_type='relu')
+        res4b19_branch2c = mx.symbol.Convolution(name='res4b19_branch2c', data=res4b19_branch2b_relu, num_filter=1024,
+                                                 pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b19_branch2c = mx.symbol.BatchNorm(name='bn4b19_branch2c', data=res4b19_branch2c, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b19_branch2c = bn4b19_branch2c
+        res4b19 = mx.symbol.broadcast_add(name='res4b19', *[res4b18_relu, scale4b19_branch2c])
+        res4b19_relu = mx.symbol.Activation(name='res4b19_relu', data=res4b19, act_type='relu')
+        res4b20_branch2a = mx.symbol.Convolution(name='res4b20_branch2a', data=res4b19_relu, num_filter=256, pad=(0, 0),
+                                                 kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b20_branch2a = mx.symbol.BatchNorm(name='bn4b20_branch2a', data=res4b20_branch2a, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b20_branch2a = bn4b20_branch2a
+        res4b20_branch2a_relu = mx.symbol.Activation(name='res4b20_branch2a_relu', data=scale4b20_branch2a,
+                                                     act_type='relu')
+        res4b20_branch2b = mx.symbol.Convolution(name='res4b20_branch2b', data=res4b20_branch2a_relu, num_filter=256,
+                                                 pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b20_branch2b = mx.symbol.BatchNorm(name='bn4b20_branch2b', data=res4b20_branch2b, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b20_branch2b = bn4b20_branch2b
+        res4b20_branch2b_relu = mx.symbol.Activation(name='res4b20_branch2b_relu', data=scale4b20_branch2b,
+                                                     act_type='relu')
+        res4b20_branch2c = mx.symbol.Convolution(name='res4b20_branch2c', data=res4b20_branch2b_relu, num_filter=1024,
+                                                 pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b20_branch2c = mx.symbol.BatchNorm(name='bn4b20_branch2c', data=res4b20_branch2c, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b20_branch2c = bn4b20_branch2c
+        res4b20 = mx.symbol.broadcast_add(name='res4b20', *[res4b19_relu, scale4b20_branch2c])
+        res4b20_relu = mx.symbol.Activation(name='res4b20_relu', data=res4b20, act_type='relu')
+        res4b21_branch2a = mx.symbol.Convolution(name='res4b21_branch2a', data=res4b20_relu, num_filter=256, pad=(0, 0),
+                                                 kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b21_branch2a = mx.symbol.BatchNorm(name='bn4b21_branch2a', data=res4b21_branch2a, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b21_branch2a = bn4b21_branch2a
+        res4b21_branch2a_relu = mx.symbol.Activation(name='res4b21_branch2a_relu', data=scale4b21_branch2a,
+                                                     act_type='relu')
+        res4b21_branch2b = mx.symbol.Convolution(name='res4b21_branch2b', data=res4b21_branch2a_relu, num_filter=256,
+                                                 pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b21_branch2b = mx.symbol.BatchNorm(name='bn4b21_branch2b', data=res4b21_branch2b, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b21_branch2b = bn4b21_branch2b
+        res4b21_branch2b_relu = mx.symbol.Activation(name='res4b21_branch2b_relu', data=scale4b21_branch2b,
+                                                     act_type='relu')
+        res4b21_branch2c = mx.symbol.Convolution(name='res4b21_branch2c', data=res4b21_branch2b_relu, num_filter=1024,
+                                                 pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b21_branch2c = mx.symbol.BatchNorm(name='bn4b21_branch2c', data=res4b21_branch2c, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b21_branch2c = bn4b21_branch2c
+        res4b21 = mx.symbol.broadcast_add(name='res4b21', *[res4b20_relu, scale4b21_branch2c])
+        res4b21_relu = mx.symbol.Activation(name='res4b21_relu', data=res4b21, act_type='relu')
+        res4b22_branch2a = mx.symbol.Convolution(name='res4b22_branch2a', data=res4b21_relu, num_filter=256, pad=(0, 0),
+                                                 kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b22_branch2a = mx.symbol.BatchNorm(name='bn4b22_branch2a', data=res4b22_branch2a, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b22_branch2a = bn4b22_branch2a
+        res4b22_branch2a_relu = mx.symbol.Activation(name='res4b22_branch2a_relu', data=scale4b22_branch2a,
+                                                     act_type='relu')
+        res4b22_branch2b = mx.symbol.Convolution(name='res4b22_branch2b', data=res4b22_branch2a_relu, num_filter=256,
+                                                 pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b22_branch2b = mx.symbol.BatchNorm(name='bn4b22_branch2b', data=res4b22_branch2b, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b22_branch2b = bn4b22_branch2b
+        res4b22_branch2b_relu = mx.symbol.Activation(name='res4b22_branch2b_relu', data=scale4b22_branch2b,
+                                                     act_type='relu')
+        res4b22_branch2c = mx.symbol.Convolution(name='res4b22_branch2c', data=res4b22_branch2b_relu, num_filter=1024,
+                                                 pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b22_branch2c = mx.symbol.BatchNorm(name='bn4b22_branch2c', data=res4b22_branch2c, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b22_branch2c = bn4b22_branch2c
+        res4b22 = mx.symbol.broadcast_add(name='res4b22', *[res4b21_relu, scale4b22_branch2c])
+        res4b22_relu = mx.symbol.Activation(name='res4b22_relu', data=res4b22, act_type='relu')
+        
+        return conv1_relu, res2c_relu, res3b3_relu, res4b10_relu, res4b22_relu
+
+    def get_resnet_v1_conv5(self, conv_feat):
+        res5a_branch1 = mx.symbol.Convolution(name='res5a_branch1', data=conv_feat, num_filter=2048, pad=(0, 0),
+                                              kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn5a_branch1 = mx.symbol.BatchNorm(name='bn5a_branch1', data=res5a_branch1, use_global_stats=True, fix_gamma=False, eps=self.eps)
+        scale5a_branch1 = bn5a_branch1
+        res5a_branch2a = mx.symbol.Convolution(name='res5a_branch2a', data=conv_feat, num_filter=512, pad=(0, 0),
+                                               kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn5a_branch2a = mx.symbol.BatchNorm(name='bn5a_branch2a', data=res5a_branch2a, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale5a_branch2a = bn5a_branch2a
+        res5a_branch2a_relu = mx.symbol.Activation(name='res5a_branch2a_relu', data=scale5a_branch2a, act_type='relu')
+        res5a_branch2b_offset = mx.symbol.Convolution(name='res5a_branch2b_offset', data = res5a_branch2a_relu,
+                                                      num_filter=72, pad=(2, 2), kernel=(3, 3), stride=(1, 1), dilate=(2, 2), cudnn_off=True)
+        res5a_branch2b = mx.contrib.symbol.DeformableConvolution(name='res5a_branch2b', data=res5a_branch2a_relu, offset=res5a_branch2b_offset,
+                                                                 num_filter=512, pad=(2, 2), kernel=(3, 3), num_deformable_group=4,
+                                                                 stride=(1, 1), dilate=(2, 2), no_bias=True)
+        bn5a_branch2b = mx.symbol.BatchNorm(name='bn5a_branch2b', data=res5a_branch2b, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale5a_branch2b = bn5a_branch2b
+        res5a_branch2b_relu = mx.symbol.Activation(name='res5a_branch2b_relu', data=scale5a_branch2b, act_type='relu')
+        res5a_branch2c = mx.symbol.Convolution(name='res5a_branch2c', data=res5a_branch2b_relu, num_filter=2048, pad=(0, 0),
+                                               kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn5a_branch2c = mx.symbol.BatchNorm(name='bn5a_branch2c', data=res5a_branch2c, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale5a_branch2c = bn5a_branch2c
+        res5a = mx.symbol.broadcast_add(name='res5a', *[scale5a_branch1, scale5a_branch2c])
+        res5a_relu = mx.symbol.Activation(name='res5a_relu', data=res5a, act_type='relu')
+        res5b_branch2a = mx.symbol.Convolution(name='res5b_branch2a', data=res5a_relu, num_filter=512, pad=(0, 0),
+                                               kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn5b_branch2a = mx.symbol.BatchNorm(name='bn5b_branch2a', data=res5b_branch2a, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale5b_branch2a = bn5b_branch2a
+        res5b_branch2a_relu = mx.symbol.Activation(name='res5b_branch2a_relu', data=scale5b_branch2a, act_type='relu')
+        res5b_branch2b_offset = mx.symbol.Convolution(name='res5b_branch2b_offset', data = res5b_branch2a_relu,
+                                                      num_filter=72, pad=(2, 2), kernel=(3, 3), stride=(1, 1), dilate=(2, 2), cudnn_off=True)
+        res5b_branch2b = mx.contrib.symbol.DeformableConvolution(name='res5b_branch2b', data=res5b_branch2a_relu, offset=res5b_branch2b_offset,
+                                                                 num_filter=512, pad=(2, 2), kernel=(3, 3), num_deformable_group=4,
+                                                                 stride=(1, 1), dilate=(2, 2), no_bias=True)
+        bn5b_branch2b = mx.symbol.BatchNorm(name='bn5b_branch2b', data=res5b_branch2b, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale5b_branch2b = bn5b_branch2b
+        res5b_branch2b_relu = mx.symbol.Activation(name='res5b_branch2b_relu', data=scale5b_branch2b, act_type='relu')
+        res5b_branch2c = mx.symbol.Convolution(name='res5b_branch2c', data=res5b_branch2b_relu, num_filter=2048, pad=(0, 0),
+                                               kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn5b_branch2c = mx.symbol.BatchNorm(name='bn5b_branch2c', data=res5b_branch2c, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale5b_branch2c = bn5b_branch2c
+        res5b = mx.symbol.broadcast_add(name='res5b', *[res5a_relu, scale5b_branch2c])
+        res5b_relu = mx.symbol.Activation(name='res5b_relu', data=res5b, act_type='relu')
+        res5c_branch2a = mx.symbol.Convolution(name='res5c_branch2a', data=res5b_relu, num_filter=512, pad=(0, 0),
+                                               kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn5c_branch2a = mx.symbol.BatchNorm(name='bn5c_branch2a', data=res5c_branch2a, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale5c_branch2a = bn5c_branch2a
+        res5c_branch2a_relu = mx.symbol.Activation(name='res5c_branch2a_relu', data=scale5c_branch2a, act_type='relu')
+        res5c_branch2b_offset = mx.symbol.Convolution(name='res5c_branch2b_offset', data = res5c_branch2a_relu,
+                                                      num_filter=72, pad=(2, 2), kernel=(3, 3), stride=(1, 1), dilate=(2, 2), cudnn_off=True)
+        res5c_branch2b = mx.contrib.symbol.DeformableConvolution(name='res5c_branch2b', data=res5c_branch2a_relu, offset=res5c_branch2b_offset,
+                                                                 num_filter=512, pad=(2, 2), kernel=(3, 3), num_deformable_group=4,
+                                                                 stride=(1, 1), dilate=(2, 2), no_bias=True)
+        bn5c_branch2b = mx.symbol.BatchNorm(name='bn5c_branch2b', data=res5c_branch2b, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale5c_branch2b = bn5c_branch2b
+        res5c_branch2b_relu = mx.symbol.Activation(name='res5c_branch2b_relu', data=scale5c_branch2b, act_type='relu')
+        res5c_branch2c = mx.symbol.Convolution(name='res5c_branch2c', data=res5c_branch2b_relu, num_filter=2048, pad=(0, 0),
+                                               kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn5c_branch2c = mx.symbol.BatchNorm(name='bn5c_branch2c', data=res5c_branch2c, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale5c_branch2c = bn5c_branch2c
+        res5c = mx.symbol.broadcast_add(name='res5c', *[res5b_relu, scale5c_branch2c])
+        res5c_relu = mx.symbol.Activation(name='res5c_relu', data=res5c, act_type='relu')
+        return res5c_relu
+
+
+    def get_rpn(self, conv_feat, num_anchors):
+        rpn_conv = mx.sym.Convolution(
+            data=conv_feat, kernel=(3, 3), pad=(1, 1), num_filter=512, name="rpn_conv_3x3")
+        rpn_relu = mx.sym.Activation(data=rpn_conv, act_type="relu", name="rpn_relu")
+        rpn_cls_score = mx.sym.Convolution(
+            data=rpn_relu, kernel=(1, 1), pad=(0, 0), num_filter=2 * num_anchors, name="rpn_cls_score")
+        rpn_bbox_pred = mx.sym.Convolution(
+            data=rpn_relu, kernel=(1, 1), pad=(0, 0), num_filter=4 * num_anchors, name="rpn_bbox_pred")
+        return rpn_cls_score, rpn_bbox_pred
+
+    def get_symbol(self, cfg, is_train=True):
+
+        # config alias for convenient
+        num_classes = cfg.dataset.NUM_CLASSES
+        num_reg_classes = (2 if cfg.CLASS_AGNOSTIC else num_classes)
+        num_anchors = cfg.network.NUM_ANCHORS
+
+        # input init
+        if is_train:
+            data = mx.sym.Variable(name="data")
+            im_info = mx.sym.Variable(name="im_info")
+            gt_boxes = mx.sym.Variable(name="gt_boxes")
+            rpn_label = mx.sym.Variable(name='label')
+            rpn_bbox_target = mx.sym.Variable(name='bbox_target')
+            rpn_bbox_weight = mx.sym.Variable(name='bbox_weight')
+        else:
+            data = mx.sym.Variable(name="data")
+            im_info = mx.sym.Variable(name="im_info")
+
+        # shared convolutional layers
+        conv1_relu, res2c_relu, res3b3_relu, res4b10_relu, conv_feat = self.get_resnet_v1_conv4(data)
+        # res5
+        relu1 = self.get_resnet_v1_conv5(conv_feat)
+
+        # TODO: Possible position for combination of all local features with the relu_1
+        # mx.sym.ROIPooling(data=conv1_relu, rois=[[]], pooled_size=desiredShape, spatial_scale=1.0)
+
+        rpn_cls_score, rpn_bbox_pred = self.get_rpn(conv_feat, num_anchors)
+
+        if is_train:
+            # prepare rpn data
+            rpn_cls_score_reshape = mx.sym.Reshape(
+                data=rpn_cls_score, shape=(0, 2, -1, 0), name="rpn_cls_score_reshape")
+
+            # classification
+            rpn_cls_prob = mx.sym.SoftmaxOutput(data=rpn_cls_score_reshape, label=rpn_label, multi_output=True,
+                                                normalization='valid', use_ignore=True, ignore_label=-1,
+                                                name="rpn_cls_prob")
+            # bounding box regression
+            rpn_bbox_loss_ = rpn_bbox_weight * mx.sym.smooth_l1(name='rpn_bbox_loss_', scalar=3.0,
+                                                                data=(rpn_bbox_pred - rpn_bbox_target))
+            rpn_bbox_loss = mx.sym.MakeLoss(name='rpn_bbox_loss', data=rpn_bbox_loss_,
+                                            grad_scale=1.0 / cfg.TRAIN.RPN_BATCH_SIZE)
+
+            # ROI proposal
+            rpn_cls_act = mx.sym.SoftmaxActivation(
+                data=rpn_cls_score_reshape, mode="channel", name="rpn_cls_act")
+            rpn_cls_act_reshape = mx.sym.Reshape(
+                data=rpn_cls_act, shape=(0, 2 * num_anchors, -1, 0), name='rpn_cls_act_reshape')
+            if cfg.TRAIN.CXX_PROPOSAL:
+                rois = mx.contrib.sym.Proposal(
+                    cls_prob=rpn_cls_act_reshape, bbox_pred=rpn_bbox_pred, im_info=im_info, name='rois',
+                    feature_stride=cfg.network.RPN_FEAT_STRIDE, scales=tuple(cfg.network.ANCHOR_SCALES),
+                    ratios=tuple(cfg.network.ANCHOR_RATIOS),
+                    rpn_pre_nms_top_n=cfg.TRAIN.RPN_PRE_NMS_TOP_N, rpn_post_nms_top_n=cfg.TRAIN.RPN_POST_NMS_TOP_N,
+                    threshold=cfg.TRAIN.RPN_NMS_THRESH, rpn_min_size=cfg.TRAIN.RPN_MIN_SIZE)
+            else:
+                rois = mx.sym.Custom(
+                    cls_prob=rpn_cls_act_reshape, bbox_pred=rpn_bbox_pred, im_info=im_info, name='rois',
+                    op_type='proposal', feat_stride=cfg.network.RPN_FEAT_STRIDE,
+                    scales=tuple(cfg.network.ANCHOR_SCALES), ratios=tuple(cfg.network.ANCHOR_RATIOS),
+                    rpn_pre_nms_top_n=cfg.TRAIN.RPN_PRE_NMS_TOP_N, rpn_post_nms_top_n=cfg.TRAIN.RPN_POST_NMS_TOP_N,
+                    threshold=cfg.TRAIN.RPN_NMS_THRESH, rpn_min_size=cfg.TRAIN.RPN_MIN_SIZE)
+            # ROI proposal target
+            gt_boxes_reshape = mx.sym.Reshape(data=gt_boxes, shape=(-1, 5), name='gt_boxes_reshape')
+            rois, label, bbox_target, bbox_weight = mx.sym.Custom(rois=rois, gt_boxes=gt_boxes_reshape,
+                                                                  op_type='proposal_target',
+                                                                  num_classes=num_reg_classes,
+                                                                  batch_images=cfg.TRAIN.BATCH_IMAGES,
+                                                                  batch_rois=cfg.TRAIN.BATCH_ROIS,
+                                                                  cfg=cPickle.dumps(cfg),
+                                                                  fg_fraction=cfg.TRAIN.FG_FRACTION)
+        else:
+            # ROI Proposal
+            rpn_cls_score_reshape = mx.sym.Reshape(
+                data=rpn_cls_score, shape=(0, 2, -1, 0), name="rpn_cls_score_reshape")
+            rpn_cls_prob = mx.sym.SoftmaxActivation(
+                data=rpn_cls_score_reshape, mode="channel", name="rpn_cls_prob")
+            rpn_cls_prob_reshape = mx.sym.Reshape(
+                data=rpn_cls_prob, shape=(0, 2 * num_anchors, -1, 0), name='rpn_cls_prob_reshape')
+            if cfg.TEST.CXX_PROPOSAL:
+                rois = mx.contrib.sym.Proposal(
+                    cls_prob=rpn_cls_prob_reshape, bbox_pred=rpn_bbox_pred, im_info=im_info, name='rois',
+                    feature_stride=cfg.network.RPN_FEAT_STRIDE, scales=tuple(cfg.network.ANCHOR_SCALES),
+                    ratios=tuple(cfg.network.ANCHOR_RATIOS),
+                    rpn_pre_nms_top_n=cfg.TEST.RPN_PRE_NMS_TOP_N, rpn_post_nms_top_n=cfg.TEST.RPN_POST_NMS_TOP_N,
+                    threshold=cfg.TEST.RPN_NMS_THRESH, rpn_min_size=cfg.TEST.RPN_MIN_SIZE)
+            else:
+                rois = mx.sym.Custom(
+                    cls_prob=rpn_cls_prob_reshape, bbox_pred=rpn_bbox_pred, im_info=im_info, name='rois',
+                    op_type='proposal', feat_stride=cfg.network.RPN_FEAT_STRIDE,
+                    scales=tuple(cfg.network.ANCHOR_SCALES), ratios=tuple(cfg.network.ANCHOR_RATIOS),
+                    rpn_pre_nms_top_n=cfg.TEST.RPN_PRE_NMS_TOP_N, rpn_post_nms_top_n=cfg.TEST.RPN_POST_NMS_TOP_N,
+                    threshold=cfg.TEST.RPN_NMS_THRESH, rpn_min_size=cfg.TEST.RPN_MIN_SIZE)
+
+        conv_new_1 = mx.sym.Convolution(data=relu1, kernel=(1, 1), num_filter=256, name="conv_new_1")
+        conv_new_1_relu = mx.sym.Activation(data=conv_new_1, act_type='relu', name='conv_new_1_relu')
+
+        # TODO: Possible position for combination of all local features with the conv_new_1_relu
+
+        offset_t = mx.contrib.sym.DeformablePSROIPooling(name='offset_t', data=conv_new_1_relu, rois=rois, group_size=1, pooled_size=7,
+                                                         sample_per_part=4, no_trans=True, part_size=7, output_dim=256, spatial_scale=0.0625)
+
+        offset = mx.sym.FullyConnected(name='offset', data=offset_t, num_hidden=7 * 7 * 2, lr_mult=0.01)
+        offset_reshape = mx.sym.Reshape(data=offset, shape=(-1, 2, 7, 7), name="offset_reshape")
+
+        deformable_roi_pool = mx.contrib.sym.DeformablePSROIPooling(name='deformable_roi_pool', data=conv_new_1_relu, rois=rois,
+                                                                    trans=offset_reshape, group_size=1, pooled_size=7, sample_per_part=4,
+                                                                    no_trans=False, part_size=7, output_dim=256, spatial_scale=1.0/16.0, trans_std=0.1)
+                                                                    # no_trans=False, part_size=7, output_dim=256, spatial_scale=0.0625, trans_std=0.1)
+
+
+        # TODO: Possible position for combination of all local features with the conv_new_1_relu
+        filterSizeForConvs = (3, 3)
+        filterPadForConvs = (1, 1)
+        conv1_relu = mx.symbol.Convolution(data=conv1_relu, kernel=filterSizeForConvs, pad=filterPadForConvs,
+                                        stride=(1, 1), num_filter=256, name="conv1_relu_256conv", no_bias=True)
+        conv1_relu = mx.symbol.Activation(data=conv1_relu, act_type='relu', name='conv1_relu_256conv_relu')
+        conv1_relu_pooled = mx.symbol.ROIPooling(name='roi_pool_conv1', data=conv1_relu, rois=rois, pooled_size=(7,7), spatial_scale=1.0/2.0)
+
+        res2c_relu = mx.symbol.Convolution(data=res2c_relu, kernel=filterSizeForConvs, pad=filterPadForConvs,
+                                        stride=(1, 1), num_filter=256, name="res2c_relu_256conv", no_bias=True)
+        res2c_relu = mx.symbol.Activation(data=res2c_relu, act_type='relu', name='res2c_relu_256conv_relu')
+        res2c_relu_pooled = mx.symbol.ROIPooling(name='roi_pool_res2c', data=res2c_relu, rois=rois, pooled_size=(7,7), spatial_scale=1.0/4.0)
+
+        res3b3_relu = mx.symbol.Convolution(data=res3b3_relu, kernel=filterSizeForConvs, pad=filterPadForConvs,
+                                        stride=(1, 1), num_filter=256, name="res3b3_relu_256conv", no_bias=True)
+        res3b3_relu = mx.symbol.Activation(data=res3b3_relu, act_type='relu', name='res3b3_relu_256conv_relu')
+        res3b3_relu_pooled = mx.symbol.ROIPooling(name='roi_pool_res3b3', data=res3b3_relu, rois=rois, pooled_size=(7,7), spatial_scale=1.0/8.0)
+
+        res4b10_relu = mx.symbol.Convolution(data=res4b10_relu, kernel=filterSizeForConvs, pad=filterPadForConvs,
+                                        stride=(1, 1), num_filter=256, name="res4b10_relu_256conv", no_bias=True)
+        res4b10_relu = mx.symbol.Activation(data=res4b10_relu, act_type='relu', name='res4b10_relu_256conv_relu')
+        res4b10_relu_pooled = mx.symbol.ROIPooling(name='roi_pool_res', data=res4b10_relu, rois=rois, pooled_size=(7,7), spatial_scale=1.0/16.0)
+
+        conv_feat = mx.symbol.Convolution(data=conv_feat, kernel=filterSizeForConvs, pad=filterPadForConvs,
+                                        stride=(1, 1), num_filter=256, name="conv_feat_256conv", no_bias=True)
+        conv_feat = mx.symbol.Activation(data=conv_feat, act_type='relu', name='conv_feat_256conv_relu')
+        conv_feat_pooled = mx.symbol.ROIPooling(name='roi_pool_res2c', data=conv_feat, rois=rois, pooled_size=(7,7), spatial_scale=1.0/16.0)
+
+        # Concatenate the different features
+        # deformable_roi_pool_new = mx.sym.concat(conv1_relu_pooled, res2c_relu_pooled, res3b3_relu_pooled, res4b10_relu_pooled, conv_feat_pooled, deformable_roi_pool, dim=1)
+        # res4b22 = mx.symbol.broadcast_add(name='res4b22', *[res4b21_relu, scale4b22_branch2c])
+        deformable_roi_pool_new = mx.symbol.add_n(conv1_relu_pooled, res2c_relu_pooled, res3b3_relu_pooled, res4b10_relu_pooled, conv_feat_pooled, deformable_roi_pool, name='features_add')
+
+        # 2 fc
+        # fc_new_1 = mx.sym.FullyConnected(name='fc_new_1', data=deformable_roi_pool, num_hidden=1024)
+        fc_new_1 = mx.sym.FullyConnected(name='fc_new_1', data=deformable_roi_pool_new, num_hidden=1024)
+        fc_new_1_relu = mx.sym.Activation(data=fc_new_1, act_type='relu', name='fc_new_1_relu')
+
+        fc_new_2 = mx.sym.FullyConnected(name='fc_new_2', data=fc_new_1_relu, num_hidden=1024)
+        fc_new_2_relu = mx.sym.Activation(data=fc_new_2, act_type='relu', name='fc_new_2_relu')
+
+        # cls_score/bbox_pred
+        cls_score = mx.sym.FullyConnected(name='cls_score', data=fc_new_2_relu, num_hidden=num_classes)
+        bbox_pred = mx.sym.FullyConnected(name='bbox_pred', data=fc_new_2_relu, num_hidden=num_reg_classes * 4)
+
+        if is_train:
+            if cfg.TRAIN.ENABLE_OHEM:
+                labels_ohem, bbox_weights_ohem = mx.sym.Custom(op_type='BoxAnnotatorOHEM', num_classes=num_classes,
+                                                               num_reg_classes=num_reg_classes,
+                                                               roi_per_img=cfg.TRAIN.BATCH_ROIS_OHEM,
+                                                               cls_score=cls_score, bbox_pred=bbox_pred, labels=label,
+                                                               bbox_targets=bbox_target, bbox_weights=bbox_weight)
+                cls_prob = mx.sym.SoftmaxOutput(name='cls_prob', data=cls_score, label=labels_ohem,
+                                                normalization='valid', use_ignore=True, ignore_label=-1)
+                bbox_loss_ = bbox_weights_ohem * mx.sym.smooth_l1(name='bbox_loss_', scalar=1.0,
+                                                                  data=(bbox_pred - bbox_target))
+                bbox_loss = mx.sym.MakeLoss(name='bbox_loss', data=bbox_loss_,
+                                            grad_scale=1.0 / cfg.TRAIN.BATCH_ROIS_OHEM)
+                rcnn_label = labels_ohem
+            else:
+                cls_prob = mx.sym.SoftmaxOutput(name='cls_prob', data=cls_score, label=label, normalization='valid')
+                bbox_loss_ = bbox_weight * mx.sym.smooth_l1(name='bbox_loss_', scalar=1.0,
+                                                            data=(bbox_pred - bbox_target))
+                bbox_loss = mx.sym.MakeLoss(name='bbox_loss', data=bbox_loss_, grad_scale=1.0 / cfg.TRAIN.BATCH_ROIS)
+                rcnn_label = label
+
+            # reshape output
+            rcnn_label = mx.sym.Reshape(data=rcnn_label, shape=(cfg.TRAIN.BATCH_IMAGES, -1), name='label_reshape')
+            cls_prob = mx.sym.Reshape(data=cls_prob, shape=(cfg.TRAIN.BATCH_IMAGES, -1, num_classes),
+                                      name='cls_prob_reshape')
+            bbox_loss = mx.sym.Reshape(data=bbox_loss, shape=(cfg.TRAIN.BATCH_IMAGES, -1, 4 * num_reg_classes),
+                                       name='bbox_loss_reshape')
+            group = mx.sym.Group([rpn_cls_prob, rpn_bbox_loss, cls_prob, bbox_loss, mx.sym.BlockGrad(rcnn_label)])
+        else:
+            cls_prob = mx.sym.SoftmaxActivation(name='cls_prob', data=cls_score)
+            cls_prob = mx.sym.Reshape(data=cls_prob, shape=(cfg.TEST.BATCH_IMAGES, -1, num_classes),
+                                      name='cls_prob_reshape')
+            bbox_pred = mx.sym.Reshape(data=bbox_pred, shape=(cfg.TEST.BATCH_IMAGES, -1, 4 * num_reg_classes),
+                                       name='bbox_pred_reshape')
+            group = mx.sym.Group([rois, cls_prob, bbox_pred])
+
+        self.sym = group
+        return group
+
+    def get_symbol_rpn(self, cfg, is_train=True):
+        # config alias for convenient
+        num_anchors = cfg.network.NUM_ANCHORS
+
+        # input init
+        if is_train:
+            data = mx.sym.Variable(name="data")
+            rpn_label = mx.sym.Variable(name='label')
+            rpn_bbox_target = mx.sym.Variable(name='bbox_target')
+            rpn_bbox_weight = mx.sym.Variable(name='bbox_weight')
+        else:
+            data = mx.sym.Variable(name="data")
+            im_info = mx.sym.Variable(name="im_info")
+
+        # shared convolutional layers
+        conv_feat = self.get_resnet_v1_conv4(data)
+        rpn_cls_score, rpn_bbox_pred = self.get_rpn(conv_feat, num_anchors)
+        if is_train:
+            # prepare rpn data
+            rpn_cls_score_reshape = mx.sym.Reshape(
+                data=rpn_cls_score, shape=(0, 2, -1, 0), name="rpn_cls_score_reshape")
+
+            # classification
+            rpn_cls_prob = mx.sym.SoftmaxOutput(data=rpn_cls_score_reshape, label=rpn_label, multi_output=True,
+                                                normalization='valid', use_ignore=True, ignore_label=-1,
+                                                name="rpn_cls_prob",
+                                                grad_scale=1.0)
+            # bounding box regression
+            rpn_bbox_loss_ = rpn_bbox_weight * mx.sym.smooth_l1(name='rpn_bbox_loss_', scalar=3.0,
+                                                                data=(rpn_bbox_pred - rpn_bbox_target))
+            rpn_bbox_loss = mx.sym.MakeLoss(name='rpn_bbox_loss', data=rpn_bbox_loss_,
+                                            grad_scale=1.0 / cfg.TRAIN.RPN_BATCH_SIZE)
+            group = mx.symbol.Group([rpn_cls_prob, rpn_bbox_loss])
+        else:
+            # ROI Proposal
+            rpn_cls_score_reshape = mx.sym.Reshape(
+                data=rpn_cls_score, shape=(0, 2, -1, 0), name="rpn_cls_score_reshape")
+            rpn_cls_prob = mx.sym.SoftmaxActivation(
+                data=rpn_cls_score_reshape, mode="channel", name="rpn_cls_prob")
+            rpn_cls_prob_reshape = mx.sym.Reshape(
+                data=rpn_cls_prob, shape=(0, 2 * num_anchors, -1, 0), name='rpn_cls_prob_reshape')
+            if cfg.TEST.CXX_PROPOSAL:
+                rois, score = mx.contrib.sym.Proposal(
+                    cls_prob=rpn_cls_prob_reshape, bbox_pred=rpn_bbox_pred, im_info=im_info, name='rois',
+                    output_score=True,
+                    feature_stride=cfg.network.RPN_FEAT_STRIDE, scales=tuple(cfg.network.ANCHOR_SCALES),
+                    ratios=tuple(cfg.network.ANCHOR_RATIOS),
+                    rpn_pre_nms_top_n=cfg.TEST.RPN_PRE_NMS_TOP_N, rpn_post_nms_top_n=cfg.TEST.RPN_POST_NMS_TOP_N,
+                    threshold=cfg.TEST.RPN_NMS_THRESH, rpn_min_size=cfg.TEST.RPN_MIN_SIZE)
+            else:
+                rois, score = mx.sym.Custom(
+                    cls_prob=rpn_cls_prob_reshape, bbox_pred=rpn_bbox_pred, im_info=im_info, name='rois',
+                    output_score=True,
+                    op_type='proposal', feat_stride=cfg.network.RPN_FEAT_STRIDE,
+                    scales=tuple(cfg.network.ANCHOR_SCALES), ratios=tuple(cfg.network.ANCHOR_RATIOS),
+                    rpn_pre_nms_top_n=cfg.TEST.RPN_PRE_NMS_TOP_N, rpn_post_nms_top_n=cfg.TEST.RPN_POST_NMS_TOP_N,
+                    threshold=cfg.TEST.RPN_NMS_THRESH, rpn_min_size=cfg.TEST.RPN_MIN_SIZE)
+                group = mx.symbol.Group([rois, score])
+        self.sym = group
+        return group
+
+    def get_symbol_rcnn(self, cfg, is_train=True):
+        # config alias for convenient
+        num_classes = cfg.dataset.NUM_CLASSES
+        num_reg_classes = (2 if cfg.CLASS_AGNOSTIC else num_classes)
+
+        # input init
+        if is_train:
+            data = mx.symbol.Variable(name="data")
+            rois = mx.symbol.Variable(name='rois')
+            label = mx.symbol.Variable(name='label')
+            bbox_target = mx.symbol.Variable(name='bbox_target')
+            bbox_weight = mx.symbol.Variable(name='bbox_weight')
+            # reshape input
+            rois = mx.symbol.Reshape(data=rois, shape=(-1, 5), name='rois_reshape')
+            label = mx.symbol.Reshape(data=label, shape=(-1,), name='label_reshape')
+            bbox_target = mx.symbol.Reshape(data=bbox_target, shape=(-1, 4 * num_classes), name='bbox_target_reshape')
+            bbox_weight = mx.symbol.Reshape(data=bbox_weight, shape=(-1, 4 * num_classes), name='bbox_weight_reshape')
+        else:
+            data = mx.sym.Variable(name="data")
+            rois = mx.symbol.Variable(name='rois')
+            # reshape input
+            rois = mx.symbol.Reshape(data=rois, shape=(-1, 5), name='rois_reshape')
+
+        # shared convolutional layers
+        conv_feat = self.get_resnet_v1_conv4(data)
+        # res5
+        relu1 = self.get_resnet_v1_conv5(conv_feat)
+
+        conv_new_1 = mx.sym.Convolution(data=relu1, kernel=(1, 1), num_filter=256, name="conv_new_1")
+        conv_new_1_relu = mx.sym.Activation(data=conv_new_1, act_type='relu', name='conv_new_1_relu')
+
+        offset_t = mx.contrib.sym.DeformablePSROIPooling(name='offset_t', data=conv_new_1_relu, rois=rois, group_size=1, pooled_size=7,
+                                                         sample_per_part=4, no_trans=True, part_size=7, output_dim=256, spatial_scale=0.0625)
+        offset = mx.sym.FullyConnected(name='offset', data=offset_t, num_hidden=7 * 7 * 2, lr_mult=0.01)
+        offset_reshape = mx.sym.Reshape(data=offset, shape=(-1, 2, 7, 7), name="offset_reshape")
+
+        deformable_roi_pool = mx.contrib.sym.DeformablePSROIPooling(name='deformable_roi_pool', data=conv_new_1_relu, rois=rois,
+                                                                    trans=offset_reshape, group_size=1, pooled_size=7, sample_per_part=4,
+                                                                    no_trans=False, part_size=7, output_dim=256, spatial_scale=0.0625, trans_std=0.1)
+
+        # 2 fc
+        fc_new_1 = mx.sym.FullyConnected(name='fc_new_1', data=deformable_roi_pool, num_hidden=1024)
+        fc_new_1_relu = mx.sym.Activation(data=fc_new_1, act_type='relu', name='fc_new_1_relu')
+
+        fc_new_2 = mx.sym.FullyConnected(name='fc_new_2', data=fc_new_1_relu, num_hidden=1024)
+        fc_new_2_relu = mx.sym.Activation(data=fc_new_2, act_type='relu', name='fc_new_2_relu')
+
+        # cls_score/bbox_pred
+        cls_score = mx.sym.FullyConnected(name='cls_score', data=fc_new_2_relu, num_hidden=num_classes)
+        bbox_pred = mx.sym.FullyConnected(name='bbox_pred', data=fc_new_2_relu, num_hidden=num_reg_classes * 4)
+
+        if is_train:
+            if cfg.TRAIN.ENABLE_OHEM:
+                labels_ohem, bbox_weights_ohem = mx.sym.Custom(op_type='BoxAnnotatorOHEM', num_classes=num_classes,
+                                                               num_reg_classes=num_reg_classes,
+                                                               roi_per_img=cfg.TRAIN.BATCH_ROIS_OHEM,
+                                                               cls_score=cls_score, bbox_pred=bbox_pred, labels=label,
+                                                               bbox_targets=bbox_target, bbox_weights=bbox_weight)
+                cls_prob = mx.sym.SoftmaxOutput(name='cls_prob', data=cls_score, label=labels_ohem,
+                                                normalization='valid', use_ignore=True, ignore_label=-1, grad_scale=1.0)
+                bbox_loss_ = bbox_weights_ohem * mx.sym.smooth_l1(name='bbox_loss_', scalar=1.0,
+                                                                  data=(bbox_pred - bbox_target))
+                bbox_loss = mx.sym.MakeLoss(name='bbox_loss', data=bbox_loss_,
+                                            grad_scale=1.0 / cfg.TRAIN.BATCH_ROIS_OHEM)
+            else:
+                cls_prob = mx.sym.SoftmaxOutput(name='cls_prob', data=cls_score, label=label, normalization='valid',
+                                                grad_scale=1.0)
+                bbox_loss_ = bbox_weight * mx.sym.smooth_l1(name='bbox_loss_', scalar=1.0,
+                                                            data=(bbox_pred - bbox_target))
+                bbox_loss = mx.sym.MakeLoss(name='bbox_loss', data=bbox_loss_, grad_scale=1.0 / cfg.TRAIN.BATCH_ROIS)
+
+            # reshape output
+            cls_prob = mx.sym.Reshape(data=cls_prob, shape=(cfg.TRAIN.BATCH_IMAGES, -1, num_classes),
+                                      name='cls_prob_reshape')
+            bbox_loss = mx.sym.Reshape(data=bbox_loss, shape=(cfg.TRAIN.BATCH_IMAGES, -1, 4 * num_reg_classes),
+                                       name='bbox_loss_reshape')
+            group = mx.sym.Group([cls_prob, bbox_loss])
+        else:
+            cls_prob = mx.sym.SoftmaxActivation(name='cls_prob', data=cls_score)
+            cls_prob = mx.sym.Reshape(data=cls_prob, shape=(cfg.TEST.BATCH_IMAGES, -1, num_classes),
+                                      name='cls_prob_reshape')
+            bbox_pred = mx.sym.Reshape(data=bbox_pred, shape=(cfg.TEST.BATCH_IMAGES, -1, 4 * num_reg_classes),
+                                       name='bbox_pred_reshape')
+            group = mx.sym.Group([cls_prob, bbox_pred])
+
+        self.sym = group
+        return group
+
+    def init_weight(self, cfg, arg_params, aux_params):
+        arg_params['rpn_conv_3x3_weight'] = mx.random.normal(0, 0.01, shape=self.arg_shape_dict['rpn_conv_3x3_weight'])
+        arg_params['rpn_conv_3x3_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['rpn_conv_3x3_bias'])
+        arg_params['rpn_cls_score_weight'] = mx.random.normal(0, 0.01, shape=self.arg_shape_dict['rpn_cls_score_weight'])
+        arg_params['rpn_cls_score_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['rpn_cls_score_bias'])
+        arg_params['rpn_bbox_pred_weight'] = mx.random.normal(0, 0.01, shape=self.arg_shape_dict['rpn_bbox_pred_weight'])
+        arg_params['rpn_bbox_pred_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['rpn_bbox_pred_bias'])
+        arg_params['res5a_branch2b_offset_weight'] = mx.nd.zeros(shape=self.arg_shape_dict['res5a_branch2b_offset_weight'])
+        arg_params['res5a_branch2b_offset_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['res5a_branch2b_offset_bias'])
+        arg_params['res5b_branch2b_offset_weight'] = mx.nd.zeros(shape=self.arg_shape_dict['res5b_branch2b_offset_weight'])
+        arg_params['res5b_branch2b_offset_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['res5b_branch2b_offset_bias'])
+        arg_params['res5c_branch2b_offset_weight'] = mx.nd.zeros(shape=self.arg_shape_dict['res5c_branch2b_offset_weight'])
+        arg_params['res5c_branch2b_offset_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['res5c_branch2b_offset_bias'])
+        arg_params['conv_new_1_weight'] = mx.random.normal(0, 0.01, shape=self.arg_shape_dict['conv_new_1_weight'])
+        arg_params['conv_new_1_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['conv_new_1_bias'])
+        arg_params['offset_weight'] = mx.nd.zeros(shape=self.arg_shape_dict['offset_weight'])
+        arg_params['offset_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['offset_bias'])
+        arg_params['fc_new_1_weight'] = mx.random.normal(0, 0.01, shape=self.arg_shape_dict['fc_new_1_weight'])
+        arg_params['fc_new_1_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['fc_new_1_bias'])
+        arg_params['fc_new_2_weight'] = mx.random.normal(0, 0.01, shape=self.arg_shape_dict['fc_new_2_weight'])
+        arg_params['fc_new_2_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['fc_new_2_bias'])
+        arg_params['cls_score_weight'] = mx.random.normal(0, 0.01, shape=self.arg_shape_dict['cls_score_weight'])
+        arg_params['cls_score_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['cls_score_bias'])
+        arg_params['bbox_pred_weight'] = mx.random.normal(0, 0.01, shape=self.arg_shape_dict['bbox_pred_weight'])
+        arg_params['bbox_pred_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['bbox_pred_bias'])
+
+        # New params
+        arg_params['conv1_relu_256conv_weight'] = mx.random.normal(0, 0.001, shape=self.arg_shape_dict['conv1_relu_256conv_weight'])
+        # arg_params['conv1_relu_256conv_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['conv1_relu_256conv_bias'])
+
+        arg_params['res2c_relu_256conv_weight'] = mx.random.normal(0, 0.001, shape=self.arg_shape_dict['res2c_relu_256conv_weight'])
+        # arg_params['res2c_relu_256conv_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['res2c_relu_256conv_bias'])
+
+        arg_params['res3b3_relu_256conv_weight'] = mx.random.normal(0, 0.001, shape=self.arg_shape_dict['res3b3_relu_256conv_weight'])
+        # arg_params['res3b3_relu_256conv_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['res3b3_relu_256conv_bias'])
+
+        arg_params['res4b10_relu_256conv_weight'] = mx.random.normal(0, 0.001, shape=self.arg_shape_dict['res4b10_relu_256conv_weight'])
+        # arg_params['res4b10_relu_256conv_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['res4b10_relu_256conv_bias'])
+
+        arg_params['conv_feat_256conv_weight'] = mx.random.normal(0, 0.001, shape=self.arg_shape_dict['conv_feat_256conv_weight'])
+        # arg_params['conv_feat_256conv_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['conv_feat_256conv_bias'])
+
+    def init_weight_rpn(self, cfg, arg_params, aux_params):
+        arg_params['rpn_conv_3x3_weight'] = mx.random.normal(0, 0.01, shape=self.arg_shape_dict['rpn_conv_3x3_weight'])
+        arg_params['rpn_conv_3x3_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['rpn_conv_3x3_bias'])
+        arg_params['rpn_cls_score_weight'] = mx.random.normal(0, 0.01,
+                                                              shape=self.arg_shape_dict['rpn_cls_score_weight'])
+        arg_params['rpn_cls_score_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['rpn_cls_score_bias'])
+        arg_params['rpn_bbox_pred_weight'] = mx.random.normal(0, 0.01,
+                                                              shape=self.arg_shape_dict['rpn_bbox_pred_weight'])
+        arg_params['rpn_bbox_pred_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['rpn_bbox_pred_bias'])
+
+    def init_weight_rcnn(self, cfg, arg_params, aux_params):
+        arg_params['res5a_branch2b_offset_weight'] = mx.nd.zeros(shape=self.arg_shape_dict['res5a_branch2b_offset_weight'])
+        arg_params['res5a_branch2b_offset_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['res5a_branch2b_offset_bias'])
+        arg_params['res5b_branch2b_offset_weight'] = mx.nd.zeros(shape=self.arg_shape_dict['res5b_branch2b_offset_weight'])
+        arg_params['res5b_branch2b_offset_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['res5b_branch2b_offset_bias'])
+        arg_params['res5c_branch2b_offset_weight'] = mx.nd.zeros(shape=self.arg_shape_dict['res5c_branch2b_offset_weight'])
+        arg_params['res5c_branch2b_offset_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['res5c_branch2b_offset_bias'])
+        arg_params['conv_new_1_weight'] = mx.random.normal(0, 0.01, shape=self.arg_shape_dict['conv_new_1_weight'])
+        arg_params['conv_new_1_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['conv_new_1_bias'])
+        arg_params['offset_weight'] = mx.nd.zeros(shape=self.arg_shape_dict['offset_weight'])
+        arg_params['offset_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['offset_bias'])
+        arg_params['fc_new_1_weight'] = mx.random.normal(0, 0.01, shape=self.arg_shape_dict['fc_new_1_weight'])
+        arg_params['fc_new_1_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['fc_new_1_bias'])
+        arg_params['fc_new_2_weight'] = mx.random.normal(0, 0.01, shape=self.arg_shape_dict['fc_new_2_weight'])
+        arg_params['fc_new_2_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['fc_new_2_bias'])
+        arg_params['cls_score_weight'] = mx.random.normal(0, 0.01, shape=self.arg_shape_dict['cls_score_weight'])
+        arg_params['cls_score_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['cls_score_bias'])
+        arg_params['bbox_pred_weight'] = mx.random.normal(0, 0.01, shape=self.arg_shape_dict['bbox_pred_weight'])
+        arg_params['bbox_pred_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['bbox_pred_bias'])
+

--- a/rfcn/symbols/resnet_v1_101_rfcn_dcn_offsets.py
+++ b/rfcn/symbols/resnet_v1_101_rfcn_dcn_offsets.py
@@ -1,0 +1,1023 @@
+# --------------------------------------------------------
+# Deformable Convolutional Networks
+# Copyright (c) 2017 Microsoft
+# Licensed under The Apache-2.0 License [see LICENSE for details]
+# Written by Yuwen Xiong, Xizhou Zhu
+# --------------------------------------------------------
+
+import cPickle
+import mxnet as mx
+from utils.symbol import Symbol
+from operator_py.proposal import *
+from operator_py.proposal_target import *
+from operator_py.box_annotator_ohem import *
+
+
+class resnet_v1_101_rfcn_dcn_offsets(Symbol):
+
+    def __init__(self):
+        """
+        Use __init__ to define parameter network needs
+        """
+        self.eps = 1e-5
+        self.use_global_stats = True
+        self.workspace = 512
+        self.units = (3, 4, 23, 3) # use for 101
+        self.filter_list = [256, 512, 1024, 2048]
+
+    def get_resnet_v1_conv4(self, data):
+        conv1 = mx.symbol.Convolution(name='conv1', data=data, num_filter=64, pad=(3, 3), kernel=(7, 7), stride=(2, 2),
+                                      no_bias=True)
+        bn_conv1 = mx.symbol.BatchNorm(name='bn_conv1', data=conv1, use_global_stats=True, fix_gamma=False, eps=self.eps)
+        scale_conv1 = bn_conv1
+        conv1_relu = mx.symbol.Activation(name='conv1_relu', data=scale_conv1, act_type='relu')
+        pool1 = mx.symbol.Pooling(name='pool1', data=conv1_relu, pooling_convention='full', pad=(0, 0), kernel=(3, 3),
+                                  stride=(2, 2), pool_type='max')
+        res2a_branch1 = mx.symbol.Convolution(name='res2a_branch1', data=pool1, num_filter=256, pad=(0, 0), kernel=(1, 1),
+                                              stride=(1, 1), no_bias=True)
+        bn2a_branch1 = mx.symbol.BatchNorm(name='bn2a_branch1', data=res2a_branch1, use_global_stats=True, fix_gamma=False, eps=self.eps)
+        scale2a_branch1 = bn2a_branch1
+        res2a_branch2a = mx.symbol.Convolution(name='res2a_branch2a', data=pool1, num_filter=64, pad=(0, 0), kernel=(1, 1),
+                                               stride=(1, 1), no_bias=True)
+        bn2a_branch2a = mx.symbol.BatchNorm(name='bn2a_branch2a', data=res2a_branch2a, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale2a_branch2a = bn2a_branch2a
+        res2a_branch2a_relu = mx.symbol.Activation(name='res2a_branch2a_relu', data=scale2a_branch2a, act_type='relu')
+        res2a_branch2b = mx.symbol.Convolution(name='res2a_branch2b', data=res2a_branch2a_relu, num_filter=64, pad=(1, 1),
+                                               kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn2a_branch2b = mx.symbol.BatchNorm(name='bn2a_branch2b', data=res2a_branch2b, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale2a_branch2b = bn2a_branch2b
+        res2a_branch2b_relu = mx.symbol.Activation(name='res2a_branch2b_relu', data=scale2a_branch2b, act_type='relu')
+        res2a_branch2c = mx.symbol.Convolution(name='res2a_branch2c', data=res2a_branch2b_relu, num_filter=256, pad=(0, 0),
+                                               kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn2a_branch2c = mx.symbol.BatchNorm(name='bn2a_branch2c', data=res2a_branch2c, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale2a_branch2c = bn2a_branch2c
+        res2a = mx.symbol.broadcast_add(name='res2a', *[scale2a_branch1, scale2a_branch2c])
+        res2a_relu = mx.symbol.Activation(name='res2a_relu', data=res2a, act_type='relu')
+        res2b_branch2a = mx.symbol.Convolution(name='res2b_branch2a', data=res2a_relu, num_filter=64, pad=(0, 0),
+                                               kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn2b_branch2a = mx.symbol.BatchNorm(name='bn2b_branch2a', data=res2b_branch2a, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale2b_branch2a = bn2b_branch2a
+        res2b_branch2a_relu = mx.symbol.Activation(name='res2b_branch2a_relu', data=scale2b_branch2a, act_type='relu')
+        res2b_branch2b = mx.symbol.Convolution(name='res2b_branch2b', data=res2b_branch2a_relu, num_filter=64, pad=(1, 1),
+                                               kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn2b_branch2b = mx.symbol.BatchNorm(name='bn2b_branch2b', data=res2b_branch2b, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale2b_branch2b = bn2b_branch2b
+        res2b_branch2b_relu = mx.symbol.Activation(name='res2b_branch2b_relu', data=scale2b_branch2b, act_type='relu')
+        res2b_branch2c = mx.symbol.Convolution(name='res2b_branch2c', data=res2b_branch2b_relu, num_filter=256, pad=(0, 0),
+                                               kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn2b_branch2c = mx.symbol.BatchNorm(name='bn2b_branch2c', data=res2b_branch2c, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale2b_branch2c = bn2b_branch2c
+        res2b = mx.symbol.broadcast_add(name='res2b', *[res2a_relu, scale2b_branch2c])
+        res2b_relu = mx.symbol.Activation(name='res2b_relu', data=res2b, act_type='relu')
+        res2c_branch2a = mx.symbol.Convolution(name='res2c_branch2a', data=res2b_relu, num_filter=64, pad=(0, 0),
+                                               kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn2c_branch2a = mx.symbol.BatchNorm(name='bn2c_branch2a', data=res2c_branch2a, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale2c_branch2a = bn2c_branch2a
+        res2c_branch2a_relu = mx.symbol.Activation(name='res2c_branch2a_relu', data=scale2c_branch2a, act_type='relu')
+        res2c_branch2b = mx.symbol.Convolution(name='res2c_branch2b', data=res2c_branch2a_relu, num_filter=64, pad=(1, 1),
+                                               kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn2c_branch2b = mx.symbol.BatchNorm(name='bn2c_branch2b', data=res2c_branch2b, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale2c_branch2b = bn2c_branch2b
+        res2c_branch2b_relu = mx.symbol.Activation(name='res2c_branch2b_relu', data=scale2c_branch2b, act_type='relu')
+        res2c_branch2c = mx.symbol.Convolution(name='res2c_branch2c', data=res2c_branch2b_relu, num_filter=256, pad=(0, 0),
+                                               kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn2c_branch2c = mx.symbol.BatchNorm(name='bn2c_branch2c', data=res2c_branch2c, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale2c_branch2c = bn2c_branch2c
+        res2c = mx.symbol.broadcast_add(name='res2c', *[res2b_relu, scale2c_branch2c])
+        res2c_relu = mx.symbol.Activation(name='res2c_relu', data=res2c, act_type='relu')
+        res3a_branch1 = mx.symbol.Convolution(name='res3a_branch1', data=res2c_relu, num_filter=512, pad=(0, 0),
+                                              kernel=(1, 1), stride=(2, 2), no_bias=True)
+        bn3a_branch1 = mx.symbol.BatchNorm(name='bn3a_branch1', data=res3a_branch1, use_global_stats=True, fix_gamma=False, eps=self.eps)
+        scale3a_branch1 = bn3a_branch1
+        res3a_branch2a = mx.symbol.Convolution(name='res3a_branch2a', data=res2c_relu, num_filter=128, pad=(0, 0),
+                                               kernel=(1, 1), stride=(2, 2), no_bias=True)
+        bn3a_branch2a = mx.symbol.BatchNorm(name='bn3a_branch2a', data=res3a_branch2a, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale3a_branch2a = bn3a_branch2a
+        res3a_branch2a_relu = mx.symbol.Activation(name='res3a_branch2a_relu', data=scale3a_branch2a, act_type='relu')
+        res3a_branch2b = mx.symbol.Convolution(name='res3a_branch2b', data=res3a_branch2a_relu, num_filter=128, pad=(1, 1),
+                                               kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn3a_branch2b = mx.symbol.BatchNorm(name='bn3a_branch2b', data=res3a_branch2b, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale3a_branch2b = bn3a_branch2b
+        res3a_branch2b_relu = mx.symbol.Activation(name='res3a_branch2b_relu', data=scale3a_branch2b, act_type='relu')
+        res3a_branch2c = mx.symbol.Convolution(name='res3a_branch2c', data=res3a_branch2b_relu, num_filter=512, pad=(0, 0),
+                                               kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn3a_branch2c = mx.symbol.BatchNorm(name='bn3a_branch2c', data=res3a_branch2c, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale3a_branch2c = bn3a_branch2c
+        res3a = mx.symbol.broadcast_add(name='res3a', *[scale3a_branch1, scale3a_branch2c])
+        res3a_relu = mx.symbol.Activation(name='res3a_relu', data=res3a, act_type='relu')
+        res3b1_branch2a = mx.symbol.Convolution(name='res3b1_branch2a', data=res3a_relu, num_filter=128, pad=(0, 0),
+                                                kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn3b1_branch2a = mx.symbol.BatchNorm(name='bn3b1_branch2a', data=res3b1_branch2a, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale3b1_branch2a = bn3b1_branch2a
+        res3b1_branch2a_relu = mx.symbol.Activation(name='res3b1_branch2a_relu', data=scale3b1_branch2a, act_type='relu')
+        res3b1_branch2b = mx.symbol.Convolution(name='res3b1_branch2b', data=res3b1_branch2a_relu, num_filter=128,
+                                                pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn3b1_branch2b = mx.symbol.BatchNorm(name='bn3b1_branch2b', data=res3b1_branch2b, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale3b1_branch2b = bn3b1_branch2b
+        res3b1_branch2b_relu = mx.symbol.Activation(name='res3b1_branch2b_relu', data=scale3b1_branch2b, act_type='relu')
+        res3b1_branch2c = mx.symbol.Convolution(name='res3b1_branch2c', data=res3b1_branch2b_relu, num_filter=512,
+                                                pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn3b1_branch2c = mx.symbol.BatchNorm(name='bn3b1_branch2c', data=res3b1_branch2c, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale3b1_branch2c = bn3b1_branch2c
+        res3b1 = mx.symbol.broadcast_add(name='res3b1', *[res3a_relu, scale3b1_branch2c])
+        res3b1_relu = mx.symbol.Activation(name='res3b1_relu', data=res3b1, act_type='relu')
+        res3b2_branch2a = mx.symbol.Convolution(name='res3b2_branch2a', data=res3b1_relu, num_filter=128, pad=(0, 0),
+                                                kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn3b2_branch2a = mx.symbol.BatchNorm(name='bn3b2_branch2a', data=res3b2_branch2a, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale3b2_branch2a = bn3b2_branch2a
+        res3b2_branch2a_relu = mx.symbol.Activation(name='res3b2_branch2a_relu', data=scale3b2_branch2a, act_type='relu')
+        res3b2_branch2b = mx.symbol.Convolution(name='res3b2_branch2b', data=res3b2_branch2a_relu, num_filter=128,
+                                                pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn3b2_branch2b = mx.symbol.BatchNorm(name='bn3b2_branch2b', data=res3b2_branch2b, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale3b2_branch2b = bn3b2_branch2b
+        res3b2_branch2b_relu = mx.symbol.Activation(name='res3b2_branch2b_relu', data=scale3b2_branch2b, act_type='relu')
+        res3b2_branch2c = mx.symbol.Convolution(name='res3b2_branch2c', data=res3b2_branch2b_relu, num_filter=512,
+                                                pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn3b2_branch2c = mx.symbol.BatchNorm(name='bn3b2_branch2c', data=res3b2_branch2c, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale3b2_branch2c = bn3b2_branch2c
+        res3b2 = mx.symbol.broadcast_add(name='res3b2', *[res3b1_relu, scale3b2_branch2c])
+        res3b2_relu = mx.symbol.Activation(name='res3b2_relu', data=res3b2, act_type='relu')
+        res3b3_branch2a = mx.symbol.Convolution(name='res3b3_branch2a', data=res3b2_relu, num_filter=128, pad=(0, 0),
+                                                kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn3b3_branch2a = mx.symbol.BatchNorm(name='bn3b3_branch2a', data=res3b3_branch2a, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale3b3_branch2a = bn3b3_branch2a
+        res3b3_branch2a_relu = mx.symbol.Activation(name='res3b3_branch2a_relu', data=scale3b3_branch2a, act_type='relu')
+        res3b3_branch2b = mx.symbol.Convolution(name='res3b3_branch2b', data=res3b3_branch2a_relu, num_filter=128,
+                                                pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn3b3_branch2b = mx.symbol.BatchNorm(name='bn3b3_branch2b', data=res3b3_branch2b, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale3b3_branch2b = bn3b3_branch2b
+        res3b3_branch2b_relu = mx.symbol.Activation(name='res3b3_branch2b_relu', data=scale3b3_branch2b, act_type='relu')
+        res3b3_branch2c = mx.symbol.Convolution(name='res3b3_branch2c', data=res3b3_branch2b_relu, num_filter=512,
+                                                pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn3b3_branch2c = mx.symbol.BatchNorm(name='bn3b3_branch2c', data=res3b3_branch2c, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale3b3_branch2c = bn3b3_branch2c
+        res3b3 = mx.symbol.broadcast_add(name='res3b3', *[res3b2_relu, scale3b3_branch2c])
+        res3b3_relu = mx.symbol.Activation(name='res3b3_relu', data=res3b3, act_type='relu')
+        res4a_branch1 = mx.symbol.Convolution(name='res4a_branch1', data=res3b3_relu, num_filter=1024, pad=(0, 0),
+                                              kernel=(1, 1), stride=(2, 2), no_bias=True)
+        bn4a_branch1 = mx.symbol.BatchNorm(name='bn4a_branch1', data=res4a_branch1, use_global_stats=True, fix_gamma=False, eps=self.eps)
+        scale4a_branch1 = bn4a_branch1
+        res4a_branch2a = mx.symbol.Convolution(name='res4a_branch2a', data=res3b3_relu, num_filter=256, pad=(0, 0),
+                                               kernel=(1, 1), stride=(2, 2), no_bias=True)
+        bn4a_branch2a = mx.symbol.BatchNorm(name='bn4a_branch2a', data=res4a_branch2a, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale4a_branch2a = bn4a_branch2a
+        res4a_branch2a_relu = mx.symbol.Activation(name='res4a_branch2a_relu', data=scale4a_branch2a, act_type='relu')
+        res4a_branch2b = mx.symbol.Convolution(name='res4a_branch2b', data=res4a_branch2a_relu, num_filter=256, pad=(1, 1),
+                                               kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4a_branch2b = mx.symbol.BatchNorm(name='bn4a_branch2b', data=res4a_branch2b, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale4a_branch2b = bn4a_branch2b
+        res4a_branch2b_relu = mx.symbol.Activation(name='res4a_branch2b_relu', data=scale4a_branch2b, act_type='relu')
+        res4a_branch2c = mx.symbol.Convolution(name='res4a_branch2c', data=res4a_branch2b_relu, num_filter=1024, pad=(0, 0),
+                                               kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4a_branch2c = mx.symbol.BatchNorm(name='bn4a_branch2c', data=res4a_branch2c, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale4a_branch2c = bn4a_branch2c
+        res4a = mx.symbol.broadcast_add(name='res4a', *[scale4a_branch1, scale4a_branch2c])
+        res4a_relu = mx.symbol.Activation(name='res4a_relu', data=res4a, act_type='relu')
+        res4b1_branch2a = mx.symbol.Convolution(name='res4b1_branch2a', data=res4a_relu, num_filter=256, pad=(0, 0),
+                                                kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b1_branch2a = mx.symbol.BatchNorm(name='bn4b1_branch2a', data=res4b1_branch2a, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b1_branch2a = bn4b1_branch2a
+        res4b1_branch2a_relu = mx.symbol.Activation(name='res4b1_branch2a_relu', data=scale4b1_branch2a, act_type='relu')
+        res4b1_branch2b = mx.symbol.Convolution(name='res4b1_branch2b', data=res4b1_branch2a_relu, num_filter=256,
+                                                pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b1_branch2b = mx.symbol.BatchNorm(name='bn4b1_branch2b', data=res4b1_branch2b, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b1_branch2b = bn4b1_branch2b
+        res4b1_branch2b_relu = mx.symbol.Activation(name='res4b1_branch2b_relu', data=scale4b1_branch2b, act_type='relu')
+        res4b1_branch2c = mx.symbol.Convolution(name='res4b1_branch2c', data=res4b1_branch2b_relu, num_filter=1024,
+                                                pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b1_branch2c = mx.symbol.BatchNorm(name='bn4b1_branch2c', data=res4b1_branch2c, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b1_branch2c = bn4b1_branch2c
+        res4b1 = mx.symbol.broadcast_add(name='res4b1', *[res4a_relu, scale4b1_branch2c])
+        res4b1_relu = mx.symbol.Activation(name='res4b1_relu', data=res4b1, act_type='relu')
+        res4b2_branch2a = mx.symbol.Convolution(name='res4b2_branch2a', data=res4b1_relu, num_filter=256, pad=(0, 0),
+                                                kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b2_branch2a = mx.symbol.BatchNorm(name='bn4b2_branch2a', data=res4b2_branch2a, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b2_branch2a = bn4b2_branch2a
+        res4b2_branch2a_relu = mx.symbol.Activation(name='res4b2_branch2a_relu', data=scale4b2_branch2a, act_type='relu')
+        res4b2_branch2b = mx.symbol.Convolution(name='res4b2_branch2b', data=res4b2_branch2a_relu, num_filter=256,
+                                                pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b2_branch2b = mx.symbol.BatchNorm(name='bn4b2_branch2b', data=res4b2_branch2b, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b2_branch2b = bn4b2_branch2b
+        res4b2_branch2b_relu = mx.symbol.Activation(name='res4b2_branch2b_relu', data=scale4b2_branch2b, act_type='relu')
+        res4b2_branch2c = mx.symbol.Convolution(name='res4b2_branch2c', data=res4b2_branch2b_relu, num_filter=1024,
+                                                pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b2_branch2c = mx.symbol.BatchNorm(name='bn4b2_branch2c', data=res4b2_branch2c, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b2_branch2c = bn4b2_branch2c
+        res4b2 = mx.symbol.broadcast_add(name='res4b2', *[res4b1_relu, scale4b2_branch2c])
+        res4b2_relu = mx.symbol.Activation(name='res4b2_relu', data=res4b2, act_type='relu')
+        res4b3_branch2a = mx.symbol.Convolution(name='res4b3_branch2a', data=res4b2_relu, num_filter=256, pad=(0, 0),
+                                                kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b3_branch2a = mx.symbol.BatchNorm(name='bn4b3_branch2a', data=res4b3_branch2a, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b3_branch2a = bn4b3_branch2a
+        res4b3_branch2a_relu = mx.symbol.Activation(name='res4b3_branch2a_relu', data=scale4b3_branch2a, act_type='relu')
+        res4b3_branch2b = mx.symbol.Convolution(name='res4b3_branch2b', data=res4b3_branch2a_relu, num_filter=256,
+                                                pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b3_branch2b = mx.symbol.BatchNorm(name='bn4b3_branch2b', data=res4b3_branch2b, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b3_branch2b = bn4b3_branch2b
+        res4b3_branch2b_relu = mx.symbol.Activation(name='res4b3_branch2b_relu', data=scale4b3_branch2b, act_type='relu')
+        res4b3_branch2c = mx.symbol.Convolution(name='res4b3_branch2c', data=res4b3_branch2b_relu, num_filter=1024,
+                                                pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b3_branch2c = mx.symbol.BatchNorm(name='bn4b3_branch2c', data=res4b3_branch2c, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b3_branch2c = bn4b3_branch2c
+        res4b3 = mx.symbol.broadcast_add(name='res4b3', *[res4b2_relu, scale4b3_branch2c])
+        res4b3_relu = mx.symbol.Activation(name='res4b3_relu', data=res4b3, act_type='relu')
+        res4b4_branch2a = mx.symbol.Convolution(name='res4b4_branch2a', data=res4b3_relu, num_filter=256, pad=(0, 0),
+                                                kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b4_branch2a = mx.symbol.BatchNorm(name='bn4b4_branch2a', data=res4b4_branch2a, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b4_branch2a = bn4b4_branch2a
+        res4b4_branch2a_relu = mx.symbol.Activation(name='res4b4_branch2a_relu', data=scale4b4_branch2a, act_type='relu')
+        res4b4_branch2b = mx.symbol.Convolution(name='res4b4_branch2b', data=res4b4_branch2a_relu, num_filter=256,
+                                                pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b4_branch2b = mx.symbol.BatchNorm(name='bn4b4_branch2b', data=res4b4_branch2b, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b4_branch2b = bn4b4_branch2b
+        res4b4_branch2b_relu = mx.symbol.Activation(name='res4b4_branch2b_relu', data=scale4b4_branch2b, act_type='relu')
+        res4b4_branch2c = mx.symbol.Convolution(name='res4b4_branch2c', data=res4b4_branch2b_relu, num_filter=1024,
+                                                pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b4_branch2c = mx.symbol.BatchNorm(name='bn4b4_branch2c', data=res4b4_branch2c, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b4_branch2c = bn4b4_branch2c
+        res4b4 = mx.symbol.broadcast_add(name='res4b4', *[res4b3_relu, scale4b4_branch2c])
+        res4b4_relu = mx.symbol.Activation(name='res4b4_relu', data=res4b4, act_type='relu')
+        res4b5_branch2a = mx.symbol.Convolution(name='res4b5_branch2a', data=res4b4_relu, num_filter=256, pad=(0, 0),
+                                                kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b5_branch2a = mx.symbol.BatchNorm(name='bn4b5_branch2a', data=res4b5_branch2a, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b5_branch2a = bn4b5_branch2a
+        res4b5_branch2a_relu = mx.symbol.Activation(name='res4b5_branch2a_relu', data=scale4b5_branch2a, act_type='relu')
+        res4b5_branch2b = mx.symbol.Convolution(name='res4b5_branch2b', data=res4b5_branch2a_relu, num_filter=256,
+                                                pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b5_branch2b = mx.symbol.BatchNorm(name='bn4b5_branch2b', data=res4b5_branch2b, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b5_branch2b = bn4b5_branch2b
+        res4b5_branch2b_relu = mx.symbol.Activation(name='res4b5_branch2b_relu', data=scale4b5_branch2b, act_type='relu')
+        res4b5_branch2c = mx.symbol.Convolution(name='res4b5_branch2c', data=res4b5_branch2b_relu, num_filter=1024,
+                                                pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b5_branch2c = mx.symbol.BatchNorm(name='bn4b5_branch2c', data=res4b5_branch2c, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b5_branch2c = bn4b5_branch2c
+        res4b5 = mx.symbol.broadcast_add(name='res4b5', *[res4b4_relu, scale4b5_branch2c])
+        res4b5_relu = mx.symbol.Activation(name='res4b5_relu', data=res4b5, act_type='relu')
+        res4b6_branch2a = mx.symbol.Convolution(name='res4b6_branch2a', data=res4b5_relu, num_filter=256, pad=(0, 0),
+                                                kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b6_branch2a = mx.symbol.BatchNorm(name='bn4b6_branch2a', data=res4b6_branch2a, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b6_branch2a = bn4b6_branch2a
+        res4b6_branch2a_relu = mx.symbol.Activation(name='res4b6_branch2a_relu', data=scale4b6_branch2a, act_type='relu')
+        res4b6_branch2b = mx.symbol.Convolution(name='res4b6_branch2b', data=res4b6_branch2a_relu, num_filter=256,
+                                                pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b6_branch2b = mx.symbol.BatchNorm(name='bn4b6_branch2b', data=res4b6_branch2b, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b6_branch2b = bn4b6_branch2b
+        res4b6_branch2b_relu = mx.symbol.Activation(name='res4b6_branch2b_relu', data=scale4b6_branch2b, act_type='relu')
+        res4b6_branch2c = mx.symbol.Convolution(name='res4b6_branch2c', data=res4b6_branch2b_relu, num_filter=1024,
+                                                pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b6_branch2c = mx.symbol.BatchNorm(name='bn4b6_branch2c', data=res4b6_branch2c, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b6_branch2c = bn4b6_branch2c
+        res4b6 = mx.symbol.broadcast_add(name='res4b6', *[res4b5_relu, scale4b6_branch2c])
+        res4b6_relu = mx.symbol.Activation(name='res4b6_relu', data=res4b6, act_type='relu')
+        res4b7_branch2a = mx.symbol.Convolution(name='res4b7_branch2a', data=res4b6_relu, num_filter=256, pad=(0, 0),
+                                                kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b7_branch2a = mx.symbol.BatchNorm(name='bn4b7_branch2a', data=res4b7_branch2a, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b7_branch2a = bn4b7_branch2a
+        res4b7_branch2a_relu = mx.symbol.Activation(name='res4b7_branch2a_relu', data=scale4b7_branch2a, act_type='relu')
+        res4b7_branch2b = mx.symbol.Convolution(name='res4b7_branch2b', data=res4b7_branch2a_relu, num_filter=256,
+                                                pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b7_branch2b = mx.symbol.BatchNorm(name='bn4b7_branch2b', data=res4b7_branch2b, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b7_branch2b = bn4b7_branch2b
+        res4b7_branch2b_relu = mx.symbol.Activation(name='res4b7_branch2b_relu', data=scale4b7_branch2b, act_type='relu')
+        res4b7_branch2c = mx.symbol.Convolution(name='res4b7_branch2c', data=res4b7_branch2b_relu, num_filter=1024,
+                                                pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b7_branch2c = mx.symbol.BatchNorm(name='bn4b7_branch2c', data=res4b7_branch2c, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b7_branch2c = bn4b7_branch2c
+        res4b7 = mx.symbol.broadcast_add(name='res4b7', *[res4b6_relu, scale4b7_branch2c])
+        res4b7_relu = mx.symbol.Activation(name='res4b7_relu', data=res4b7, act_type='relu')
+        res4b8_branch2a = mx.symbol.Convolution(name='res4b8_branch2a', data=res4b7_relu, num_filter=256, pad=(0, 0),
+                                                kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b8_branch2a = mx.symbol.BatchNorm(name='bn4b8_branch2a', data=res4b8_branch2a, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b8_branch2a = bn4b8_branch2a
+        res4b8_branch2a_relu = mx.symbol.Activation(name='res4b8_branch2a_relu', data=scale4b8_branch2a, act_type='relu')
+        res4b8_branch2b = mx.symbol.Convolution(name='res4b8_branch2b', data=res4b8_branch2a_relu, num_filter=256,
+                                                pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b8_branch2b = mx.symbol.BatchNorm(name='bn4b8_branch2b', data=res4b8_branch2b, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b8_branch2b = bn4b8_branch2b
+        res4b8_branch2b_relu = mx.symbol.Activation(name='res4b8_branch2b_relu', data=scale4b8_branch2b, act_type='relu')
+        res4b8_branch2c = mx.symbol.Convolution(name='res4b8_branch2c', data=res4b8_branch2b_relu, num_filter=1024,
+                                                pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b8_branch2c = mx.symbol.BatchNorm(name='bn4b8_branch2c', data=res4b8_branch2c, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b8_branch2c = bn4b8_branch2c
+        res4b8 = mx.symbol.broadcast_add(name='res4b8', *[res4b7_relu, scale4b8_branch2c])
+        res4b8_relu = mx.symbol.Activation(name='res4b8_relu', data=res4b8, act_type='relu')
+        res4b9_branch2a = mx.symbol.Convolution(name='res4b9_branch2a', data=res4b8_relu, num_filter=256, pad=(0, 0),
+                                                kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b9_branch2a = mx.symbol.BatchNorm(name='bn4b9_branch2a', data=res4b9_branch2a, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b9_branch2a = bn4b9_branch2a
+        res4b9_branch2a_relu = mx.symbol.Activation(name='res4b9_branch2a_relu', data=scale4b9_branch2a, act_type='relu')
+        res4b9_branch2b = mx.symbol.Convolution(name='res4b9_branch2b', data=res4b9_branch2a_relu, num_filter=256,
+                                                pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b9_branch2b = mx.symbol.BatchNorm(name='bn4b9_branch2b', data=res4b9_branch2b, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b9_branch2b = bn4b9_branch2b
+        res4b9_branch2b_relu = mx.symbol.Activation(name='res4b9_branch2b_relu', data=scale4b9_branch2b, act_type='relu')
+        res4b9_branch2c = mx.symbol.Convolution(name='res4b9_branch2c', data=res4b9_branch2b_relu, num_filter=1024,
+                                                pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b9_branch2c = mx.symbol.BatchNorm(name='bn4b9_branch2c', data=res4b9_branch2c, use_global_stats=True,
+                                             fix_gamma=False, eps=self.eps)
+        scale4b9_branch2c = bn4b9_branch2c
+        res4b9 = mx.symbol.broadcast_add(name='res4b9', *[res4b8_relu, scale4b9_branch2c])
+        res4b9_relu = mx.symbol.Activation(name='res4b9_relu', data=res4b9, act_type='relu')
+        res4b10_branch2a = mx.symbol.Convolution(name='res4b10_branch2a', data=res4b9_relu, num_filter=256, pad=(0, 0),
+                                                 kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b10_branch2a = mx.symbol.BatchNorm(name='bn4b10_branch2a', data=res4b10_branch2a, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b10_branch2a = bn4b10_branch2a
+        res4b10_branch2a_relu = mx.symbol.Activation(name='res4b10_branch2a_relu', data=scale4b10_branch2a, act_type='relu')
+        res4b10_branch2b = mx.symbol.Convolution(name='res4b10_branch2b', data=res4b10_branch2a_relu, num_filter=256,
+                                                 pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b10_branch2b = mx.symbol.BatchNorm(name='bn4b10_branch2b', data=res4b10_branch2b, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b10_branch2b = bn4b10_branch2b
+        res4b10_branch2b_relu = mx.symbol.Activation(name='res4b10_branch2b_relu', data=scale4b10_branch2b, act_type='relu')
+        res4b10_branch2c = mx.symbol.Convolution(name='res4b10_branch2c', data=res4b10_branch2b_relu, num_filter=1024,
+                                                 pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b10_branch2c = mx.symbol.BatchNorm(name='bn4b10_branch2c', data=res4b10_branch2c, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b10_branch2c = bn4b10_branch2c
+        res4b10 = mx.symbol.broadcast_add(name='res4b10', *[res4b9_relu, scale4b10_branch2c])
+        res4b10_relu = mx.symbol.Activation(name='res4b10_relu', data=res4b10, act_type='relu')
+        res4b11_branch2a = mx.symbol.Convolution(name='res4b11_branch2a', data=res4b10_relu, num_filter=256, pad=(0, 0),
+                                                 kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b11_branch2a = mx.symbol.BatchNorm(name='bn4b11_branch2a', data=res4b11_branch2a, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b11_branch2a = bn4b11_branch2a
+        res4b11_branch2a_relu = mx.symbol.Activation(name='res4b11_branch2a_relu', data=scale4b11_branch2a, act_type='relu')
+        res4b11_branch2b = mx.symbol.Convolution(name='res4b11_branch2b', data=res4b11_branch2a_relu, num_filter=256,
+                                                 pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b11_branch2b = mx.symbol.BatchNorm(name='bn4b11_branch2b', data=res4b11_branch2b, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b11_branch2b = bn4b11_branch2b
+        res4b11_branch2b_relu = mx.symbol.Activation(name='res4b11_branch2b_relu', data=scale4b11_branch2b, act_type='relu')
+        res4b11_branch2c = mx.symbol.Convolution(name='res4b11_branch2c', data=res4b11_branch2b_relu, num_filter=1024,
+                                                 pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b11_branch2c = mx.symbol.BatchNorm(name='bn4b11_branch2c', data=res4b11_branch2c, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b11_branch2c = bn4b11_branch2c
+        res4b11 = mx.symbol.broadcast_add(name='res4b11', *[res4b10_relu, scale4b11_branch2c])
+        res4b11_relu = mx.symbol.Activation(name='res4b11_relu', data=res4b11, act_type='relu')
+        res4b12_branch2a = mx.symbol.Convolution(name='res4b12_branch2a', data=res4b11_relu, num_filter=256, pad=(0, 0),
+                                                 kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b12_branch2a = mx.symbol.BatchNorm(name='bn4b12_branch2a', data=res4b12_branch2a, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b12_branch2a = bn4b12_branch2a
+        res4b12_branch2a_relu = mx.symbol.Activation(name='res4b12_branch2a_relu', data=scale4b12_branch2a, act_type='relu')
+        res4b12_branch2b = mx.symbol.Convolution(name='res4b12_branch2b', data=res4b12_branch2a_relu, num_filter=256,
+                                                 pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b12_branch2b = mx.symbol.BatchNorm(name='bn4b12_branch2b', data=res4b12_branch2b, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b12_branch2b = bn4b12_branch2b
+        res4b12_branch2b_relu = mx.symbol.Activation(name='res4b12_branch2b_relu', data=scale4b12_branch2b, act_type='relu')
+        res4b12_branch2c = mx.symbol.Convolution(name='res4b12_branch2c', data=res4b12_branch2b_relu, num_filter=1024,
+                                                 pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b12_branch2c = mx.symbol.BatchNorm(name='bn4b12_branch2c', data=res4b12_branch2c, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b12_branch2c = bn4b12_branch2c
+        res4b12 = mx.symbol.broadcast_add(name='res4b12', *[res4b11_relu, scale4b12_branch2c])
+        res4b12_relu = mx.symbol.Activation(name='res4b12_relu', data=res4b12, act_type='relu')
+        res4b13_branch2a = mx.symbol.Convolution(name='res4b13_branch2a', data=res4b12_relu, num_filter=256, pad=(0, 0),
+                                                 kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b13_branch2a = mx.symbol.BatchNorm(name='bn4b13_branch2a', data=res4b13_branch2a, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b13_branch2a = bn4b13_branch2a
+        res4b13_branch2a_relu = mx.symbol.Activation(name='res4b13_branch2a_relu', data=scale4b13_branch2a, act_type='relu')
+        res4b13_branch2b = mx.symbol.Convolution(name='res4b13_branch2b', data=res4b13_branch2a_relu, num_filter=256,
+                                                 pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b13_branch2b = mx.symbol.BatchNorm(name='bn4b13_branch2b', data=res4b13_branch2b, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b13_branch2b = bn4b13_branch2b
+        res4b13_branch2b_relu = mx.symbol.Activation(name='res4b13_branch2b_relu', data=scale4b13_branch2b, act_type='relu')
+        res4b13_branch2c = mx.symbol.Convolution(name='res4b13_branch2c', data=res4b13_branch2b_relu, num_filter=1024,
+                                                 pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b13_branch2c = mx.symbol.BatchNorm(name='bn4b13_branch2c', data=res4b13_branch2c, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b13_branch2c = bn4b13_branch2c
+        res4b13 = mx.symbol.broadcast_add(name='res4b13', *[res4b12_relu, scale4b13_branch2c])
+        res4b13_relu = mx.symbol.Activation(name='res4b13_relu', data=res4b13, act_type='relu')
+        res4b14_branch2a = mx.symbol.Convolution(name='res4b14_branch2a', data=res4b13_relu, num_filter=256, pad=(0, 0),
+                                                 kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b14_branch2a = mx.symbol.BatchNorm(name='bn4b14_branch2a', data=res4b14_branch2a, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b14_branch2a = bn4b14_branch2a
+        res4b14_branch2a_relu = mx.symbol.Activation(name='res4b14_branch2a_relu', data=scale4b14_branch2a, act_type='relu')
+        res4b14_branch2b = mx.symbol.Convolution(name='res4b14_branch2b', data=res4b14_branch2a_relu, num_filter=256,
+                                                 pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b14_branch2b = mx.symbol.BatchNorm(name='bn4b14_branch2b', data=res4b14_branch2b, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b14_branch2b = bn4b14_branch2b
+        res4b14_branch2b_relu = mx.symbol.Activation(name='res4b14_branch2b_relu', data=scale4b14_branch2b, act_type='relu')
+        res4b14_branch2c = mx.symbol.Convolution(name='res4b14_branch2c', data=res4b14_branch2b_relu, num_filter=1024,
+                                                 pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b14_branch2c = mx.symbol.BatchNorm(name='bn4b14_branch2c', data=res4b14_branch2c, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b14_branch2c = bn4b14_branch2c
+        res4b14 = mx.symbol.broadcast_add(name='res4b14', *[res4b13_relu, scale4b14_branch2c])
+        res4b14_relu = mx.symbol.Activation(name='res4b14_relu', data=res4b14, act_type='relu')
+        res4b15_branch2a = mx.symbol.Convolution(name='res4b15_branch2a', data=res4b14_relu, num_filter=256, pad=(0, 0),
+                                                 kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b15_branch2a = mx.symbol.BatchNorm(name='bn4b15_branch2a', data=res4b15_branch2a, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b15_branch2a = bn4b15_branch2a
+        res4b15_branch2a_relu = mx.symbol.Activation(name='res4b15_branch2a_relu', data=scale4b15_branch2a, act_type='relu')
+        res4b15_branch2b = mx.symbol.Convolution(name='res4b15_branch2b', data=res4b15_branch2a_relu, num_filter=256,
+                                                 pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b15_branch2b = mx.symbol.BatchNorm(name='bn4b15_branch2b', data=res4b15_branch2b, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b15_branch2b = bn4b15_branch2b
+        res4b15_branch2b_relu = mx.symbol.Activation(name='res4b15_branch2b_relu', data=scale4b15_branch2b, act_type='relu')
+        res4b15_branch2c = mx.symbol.Convolution(name='res4b15_branch2c', data=res4b15_branch2b_relu, num_filter=1024,
+                                                 pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b15_branch2c = mx.symbol.BatchNorm(name='bn4b15_branch2c', data=res4b15_branch2c, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b15_branch2c = bn4b15_branch2c
+        res4b15 = mx.symbol.broadcast_add(name='res4b15', *[res4b14_relu, scale4b15_branch2c])
+        res4b15_relu = mx.symbol.Activation(name='res4b15_relu', data=res4b15, act_type='relu')
+        res4b16_branch2a = mx.symbol.Convolution(name='res4b16_branch2a', data=res4b15_relu, num_filter=256, pad=(0, 0),
+                                                 kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b16_branch2a = mx.symbol.BatchNorm(name='bn4b16_branch2a', data=res4b16_branch2a, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b16_branch2a = bn4b16_branch2a
+        res4b16_branch2a_relu = mx.symbol.Activation(name='res4b16_branch2a_relu', data=scale4b16_branch2a, act_type='relu')
+        res4b16_branch2b = mx.symbol.Convolution(name='res4b16_branch2b', data=res4b16_branch2a_relu, num_filter=256,
+                                                 pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b16_branch2b = mx.symbol.BatchNorm(name='bn4b16_branch2b', data=res4b16_branch2b, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b16_branch2b = bn4b16_branch2b
+        res4b16_branch2b_relu = mx.symbol.Activation(name='res4b16_branch2b_relu', data=scale4b16_branch2b, act_type='relu')
+        res4b16_branch2c = mx.symbol.Convolution(name='res4b16_branch2c', data=res4b16_branch2b_relu, num_filter=1024,
+                                                 pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b16_branch2c = mx.symbol.BatchNorm(name='bn4b16_branch2c', data=res4b16_branch2c, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b16_branch2c = bn4b16_branch2c
+        res4b16 = mx.symbol.broadcast_add(name='res4b16', *[res4b15_relu, scale4b16_branch2c])
+        res4b16_relu = mx.symbol.Activation(name='res4b16_relu', data=res4b16, act_type='relu')
+        res4b17_branch2a = mx.symbol.Convolution(name='res4b17_branch2a', data=res4b16_relu, num_filter=256, pad=(0, 0),
+                                                 kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b17_branch2a = mx.symbol.BatchNorm(name='bn4b17_branch2a', data=res4b17_branch2a, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b17_branch2a = bn4b17_branch2a
+        res4b17_branch2a_relu = mx.symbol.Activation(name='res4b17_branch2a_relu', data=scale4b17_branch2a, act_type='relu')
+        res4b17_branch2b = mx.symbol.Convolution(name='res4b17_branch2b', data=res4b17_branch2a_relu, num_filter=256,
+                                                 pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b17_branch2b = mx.symbol.BatchNorm(name='bn4b17_branch2b', data=res4b17_branch2b, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b17_branch2b = bn4b17_branch2b
+        res4b17_branch2b_relu = mx.symbol.Activation(name='res4b17_branch2b_relu', data=scale4b17_branch2b, act_type='relu')
+        res4b17_branch2c = mx.symbol.Convolution(name='res4b17_branch2c', data=res4b17_branch2b_relu, num_filter=1024,
+                                                 pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b17_branch2c = mx.symbol.BatchNorm(name='bn4b17_branch2c', data=res4b17_branch2c, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b17_branch2c = bn4b17_branch2c
+        res4b17 = mx.symbol.broadcast_add(name='res4b17', *[res4b16_relu, scale4b17_branch2c])
+        res4b17_relu = mx.symbol.Activation(name='res4b17_relu', data=res4b17, act_type='relu')
+        res4b18_branch2a = mx.symbol.Convolution(name='res4b18_branch2a', data=res4b17_relu, num_filter=256, pad=(0, 0),
+                                                 kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b18_branch2a = mx.symbol.BatchNorm(name='bn4b18_branch2a', data=res4b18_branch2a, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b18_branch2a = bn4b18_branch2a
+        res4b18_branch2a_relu = mx.symbol.Activation(name='res4b18_branch2a_relu', data=scale4b18_branch2a, act_type='relu')
+        res4b18_branch2b = mx.symbol.Convolution(name='res4b18_branch2b', data=res4b18_branch2a_relu, num_filter=256,
+                                                 pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b18_branch2b = mx.symbol.BatchNorm(name='bn4b18_branch2b', data=res4b18_branch2b, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b18_branch2b = bn4b18_branch2b
+        res4b18_branch2b_relu = mx.symbol.Activation(name='res4b18_branch2b_relu', data=scale4b18_branch2b, act_type='relu')
+        res4b18_branch2c = mx.symbol.Convolution(name='res4b18_branch2c', data=res4b18_branch2b_relu, num_filter=1024,
+                                                 pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b18_branch2c = mx.symbol.BatchNorm(name='bn4b18_branch2c', data=res4b18_branch2c, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b18_branch2c = bn4b18_branch2c
+        res4b18 = mx.symbol.broadcast_add(name='res4b18', *[res4b17_relu, scale4b18_branch2c])
+        res4b18_relu = mx.symbol.Activation(name='res4b18_relu', data=res4b18, act_type='relu')
+        res4b19_branch2a = mx.symbol.Convolution(name='res4b19_branch2a', data=res4b18_relu, num_filter=256, pad=(0, 0),
+                                                 kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b19_branch2a = mx.symbol.BatchNorm(name='bn4b19_branch2a', data=res4b19_branch2a, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b19_branch2a = bn4b19_branch2a
+        res4b19_branch2a_relu = mx.symbol.Activation(name='res4b19_branch2a_relu', data=scale4b19_branch2a, act_type='relu')
+        res4b19_branch2b = mx.symbol.Convolution(name='res4b19_branch2b', data=res4b19_branch2a_relu, num_filter=256,
+                                                 pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b19_branch2b = mx.symbol.BatchNorm(name='bn4b19_branch2b', data=res4b19_branch2b, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b19_branch2b = bn4b19_branch2b
+        res4b19_branch2b_relu = mx.symbol.Activation(name='res4b19_branch2b_relu', data=scale4b19_branch2b, act_type='relu')
+        res4b19_branch2c = mx.symbol.Convolution(name='res4b19_branch2c', data=res4b19_branch2b_relu, num_filter=1024,
+                                                 pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b19_branch2c = mx.symbol.BatchNorm(name='bn4b19_branch2c', data=res4b19_branch2c, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b19_branch2c = bn4b19_branch2c
+        res4b19 = mx.symbol.broadcast_add(name='res4b19', *[res4b18_relu, scale4b19_branch2c])
+        res4b19_relu = mx.symbol.Activation(name='res4b19_relu', data=res4b19, act_type='relu')
+        res4b20_branch2a = mx.symbol.Convolution(name='res4b20_branch2a', data=res4b19_relu, num_filter=256, pad=(0, 0),
+                                                 kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b20_branch2a = mx.symbol.BatchNorm(name='bn4b20_branch2a', data=res4b20_branch2a, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b20_branch2a = bn4b20_branch2a
+        res4b20_branch2a_relu = mx.symbol.Activation(name='res4b20_branch2a_relu', data=scale4b20_branch2a, act_type='relu')
+        res4b20_branch2b = mx.symbol.Convolution(name='res4b20_branch2b', data=res4b20_branch2a_relu, num_filter=256,
+                                                 pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b20_branch2b = mx.symbol.BatchNorm(name='bn4b20_branch2b', data=res4b20_branch2b, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b20_branch2b = bn4b20_branch2b
+        res4b20_branch2b_relu = mx.symbol.Activation(name='res4b20_branch2b_relu', data=scale4b20_branch2b, act_type='relu')
+        res4b20_branch2c = mx.symbol.Convolution(name='res4b20_branch2c', data=res4b20_branch2b_relu, num_filter=1024,
+                                                 pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b20_branch2c = mx.symbol.BatchNorm(name='bn4b20_branch2c', data=res4b20_branch2c, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b20_branch2c = bn4b20_branch2c
+        res4b20 = mx.symbol.broadcast_add(name='res4b20', *[res4b19_relu, scale4b20_branch2c])
+        res4b20_relu = mx.symbol.Activation(name='res4b20_relu', data=res4b20, act_type='relu')
+        res4b21_branch2a = mx.symbol.Convolution(name='res4b21_branch2a', data=res4b20_relu, num_filter=256, pad=(0, 0),
+                                                 kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b21_branch2a = mx.symbol.BatchNorm(name='bn4b21_branch2a', data=res4b21_branch2a, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b21_branch2a = bn4b21_branch2a
+        res4b21_branch2a_relu = mx.symbol.Activation(name='res4b21_branch2a_relu', data=scale4b21_branch2a, act_type='relu')
+        res4b21_branch2b = mx.symbol.Convolution(name='res4b21_branch2b', data=res4b21_branch2a_relu, num_filter=256,
+                                                 pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b21_branch2b = mx.symbol.BatchNorm(name='bn4b21_branch2b', data=res4b21_branch2b, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b21_branch2b = bn4b21_branch2b
+        res4b21_branch2b_relu = mx.symbol.Activation(name='res4b21_branch2b_relu', data=scale4b21_branch2b, act_type='relu')
+        res4b21_branch2c = mx.symbol.Convolution(name='res4b21_branch2c', data=res4b21_branch2b_relu, num_filter=1024,
+                                                 pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b21_branch2c = mx.symbol.BatchNorm(name='bn4b21_branch2c', data=res4b21_branch2c, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b21_branch2c = bn4b21_branch2c
+        res4b21 = mx.symbol.broadcast_add(name='res4b21', *[res4b20_relu, scale4b21_branch2c])
+        res4b21_relu = mx.symbol.Activation(name='res4b21_relu', data=res4b21, act_type='relu')
+        res4b22_branch2a = mx.symbol.Convolution(name='res4b22_branch2a', data=res4b21_relu, num_filter=256, pad=(0, 0),
+                                                 kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b22_branch2a = mx.symbol.BatchNorm(name='bn4b22_branch2a', data=res4b22_branch2a, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b22_branch2a = bn4b22_branch2a
+        res4b22_branch2a_relu = mx.symbol.Activation(name='res4b22_branch2a_relu', data=scale4b22_branch2a, act_type='relu')
+        res4b22_branch2b = mx.symbol.Convolution(name='res4b22_branch2b', data=res4b22_branch2a_relu, num_filter=256,
+                                                 pad=(1, 1), kernel=(3, 3), stride=(1, 1), no_bias=True)
+        bn4b22_branch2b = mx.symbol.BatchNorm(name='bn4b22_branch2b', data=res4b22_branch2b, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b22_branch2b = bn4b22_branch2b
+        res4b22_branch2b_relu = mx.symbol.Activation(name='res4b22_branch2b_relu', data=scale4b22_branch2b, act_type='relu')
+        res4b22_branch2c = mx.symbol.Convolution(name='res4b22_branch2c', data=res4b22_branch2b_relu, num_filter=1024,
+                                                 pad=(0, 0), kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn4b22_branch2c = mx.symbol.BatchNorm(name='bn4b22_branch2c', data=res4b22_branch2c, use_global_stats=True,
+                                              fix_gamma=False, eps=self.eps)
+        scale4b22_branch2c = bn4b22_branch2c
+        res4b22 = mx.symbol.broadcast_add(name='res4b22', *[res4b21_relu, scale4b22_branch2c])
+        res4b22_relu = mx.symbol.Activation(name='res4b22_relu', data=res4b22, act_type='relu')
+        return res4b22_relu
+        
+    def get_resnet_v1_conv5(self, conv_feat):
+        res5a_branch1 = mx.symbol.Convolution(name='res5a_branch1', data=conv_feat, num_filter=2048, pad=(0, 0),
+                                              kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn5a_branch1 = mx.symbol.BatchNorm(name='bn5a_branch1', data=res5a_branch1, use_global_stats=True, fix_gamma=False, eps=self.eps)
+        scale5a_branch1 = bn5a_branch1
+        res5a_branch2a = mx.symbol.Convolution(name='res5a_branch2a', data=conv_feat, num_filter=512, pad=(0, 0),
+                                               kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn5a_branch2a = mx.symbol.BatchNorm(name='bn5a_branch2a', data=res5a_branch2a, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale5a_branch2a = bn5a_branch2a
+        res5a_branch2a_relu = mx.symbol.Activation(name='res5a_branch2a_relu', data=scale5a_branch2a, act_type='relu')
+        res5a_branch2b_offset = mx.symbol.Convolution(name='res5a_branch2b_offset', data = res5a_branch2a_relu,
+                                                      num_filter=72, pad=(2, 2), kernel=(3, 3), stride=(1, 1), dilate=(2, 2), cudnn_off=True)
+        res5a_branch2b = mx.contrib.symbol.DeformableConvolution(name='res5a_branch2b', data=res5a_branch2a_relu, offset=res5a_branch2b_offset,
+                                                                 num_filter=512, pad=(2, 2), kernel=(3, 3), num_deformable_group=4,
+                                                                 stride=(1, 1), dilate=(2, 2), no_bias=True)
+        bn5a_branch2b = mx.symbol.BatchNorm(name='bn5a_branch2b', data=res5a_branch2b, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale5a_branch2b = bn5a_branch2b
+        res5a_branch2b_relu = mx.symbol.Activation(name='res5a_branch2b_relu', data=scale5a_branch2b, act_type='relu')
+        res5a_branch2c = mx.symbol.Convolution(name='res5a_branch2c', data=res5a_branch2b_relu, num_filter=2048, pad=(0, 0),
+                                               kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn5a_branch2c = mx.symbol.BatchNorm(name='bn5a_branch2c', data=res5a_branch2c, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale5a_branch2c = bn5a_branch2c
+        res5a = mx.symbol.broadcast_add(name='res5a', *[scale5a_branch1, scale5a_branch2c])
+        res5a_relu = mx.symbol.Activation(name='res5a_relu', data=res5a, act_type='relu')
+        res5b_branch2a = mx.symbol.Convolution(name='res5b_branch2a', data=res5a_relu, num_filter=512, pad=(0, 0),
+                                               kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn5b_branch2a = mx.symbol.BatchNorm(name='bn5b_branch2a', data=res5b_branch2a, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale5b_branch2a = bn5b_branch2a
+        res5b_branch2a_relu = mx.symbol.Activation(name='res5b_branch2a_relu', data=scale5b_branch2a, act_type='relu')
+        res5b_branch2b_offset = mx.symbol.Convolution(name='res5b_branch2b_offset', data = res5b_branch2a_relu,
+                                                      num_filter=72, pad=(2, 2), kernel=(3, 3), stride=(1, 1), dilate=(2, 2), cudnn_off=True)
+        res5b_branch2b = mx.contrib.symbol.DeformableConvolution(name='res5b_branch2b', data=res5b_branch2a_relu, offset=res5b_branch2b_offset,
+                                                                 num_filter=512, pad=(2, 2), kernel=(3, 3), num_deformable_group=4,
+                                                                 stride=(1, 1), dilate=(2, 2), no_bias=True)
+        bn5b_branch2b = mx.symbol.BatchNorm(name='bn5b_branch2b', data=res5b_branch2b, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale5b_branch2b = bn5b_branch2b
+        res5b_branch2b_relu = mx.symbol.Activation(name='res5b_branch2b_relu', data=scale5b_branch2b, act_type='relu')
+        res5b_branch2c = mx.symbol.Convolution(name='res5b_branch2c', data=res5b_branch2b_relu, num_filter=2048, pad=(0, 0),
+                                               kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn5b_branch2c = mx.symbol.BatchNorm(name='bn5b_branch2c', data=res5b_branch2c, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale5b_branch2c = bn5b_branch2c
+        res5b = mx.symbol.broadcast_add(name='res5b', *[res5a_relu, scale5b_branch2c])
+        res5b_relu = mx.symbol.Activation(name='res5b_relu', data=res5b, act_type='relu')
+        res5c_branch2a = mx.symbol.Convolution(name='res5c_branch2a', data=res5b_relu, num_filter=512, pad=(0, 0),
+                                               kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn5c_branch2a = mx.symbol.BatchNorm(name='bn5c_branch2a', data=res5c_branch2a, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale5c_branch2a = bn5c_branch2a
+        res5c_branch2a_relu = mx.symbol.Activation(name='res5c_branch2a_relu', data=scale5c_branch2a, act_type='relu')
+        res5c_branch2b_offset = mx.symbol.Convolution(name='res5c_branch2b_offset', data = res5c_branch2a_relu,
+                                                      num_filter=72, pad=(2, 2), kernel=(3, 3), stride=(1, 1), dilate=(2, 2), cudnn_off=True)
+        res5c_branch2b = mx.contrib.symbol.DeformableConvolution(name='res5c_branch2b', data=res5c_branch2a_relu, offset=res5c_branch2b_offset,
+                                                                 num_filter=512, pad=(2, 2), kernel=(3, 3), num_deformable_group=4,
+                                                                 stride=(1, 1), dilate=(2, 2), no_bias=True)
+        bn5c_branch2b = mx.symbol.BatchNorm(name='bn5c_branch2b', data=res5c_branch2b, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale5c_branch2b = bn5c_branch2b
+        res5c_branch2b_relu = mx.symbol.Activation(name='res5c_branch2b_relu', data=scale5c_branch2b, act_type='relu')
+        res5c_branch2c = mx.symbol.Convolution(name='res5c_branch2c', data=res5c_branch2b_relu, num_filter=2048, pad=(0, 0),
+                                               kernel=(1, 1), stride=(1, 1), no_bias=True)
+        bn5c_branch2c = mx.symbol.BatchNorm(name='bn5c_branch2c', data=res5c_branch2c, use_global_stats=True,
+                                            fix_gamma=False, eps=self.eps)
+        scale5c_branch2c = bn5c_branch2c
+        res5c = mx.symbol.broadcast_add(name='res5c', *[res5b_relu, scale5c_branch2c])
+        res5c_relu = mx.symbol.Activation(name='res5c_relu', data=res5c, act_type='relu')
+        # return res5c_relu
+        return res5c_relu, res5a_branch2b_offset, res5b_branch2b_offset, res5c_branch2b_offset
+
+    def get_rpn(self, conv_feat, num_anchors):
+        rpn_conv = mx.sym.Convolution(
+            data=conv_feat, kernel=(3, 3), pad=(1, 1), num_filter=512, name="rpn_conv_3x3")
+        rpn_relu = mx.sym.Activation(data=rpn_conv, act_type="relu", name="rpn_relu")
+        rpn_cls_score = mx.sym.Convolution(
+            data=rpn_relu, kernel=(1, 1), pad=(0, 0), num_filter=2 * num_anchors, name="rpn_cls_score")
+        rpn_bbox_pred = mx.sym.Convolution(
+            data=rpn_relu, kernel=(1, 1), pad=(0, 0), num_filter=4 * num_anchors, name="rpn_bbox_pred")
+        return rpn_cls_score, rpn_bbox_pred
+
+    def get_symbol(self, cfg, is_train=True):
+
+        # config alias for convenient
+        num_classes = cfg.dataset.NUM_CLASSES
+        num_reg_classes = (2 if cfg.CLASS_AGNOSTIC else num_classes)
+        num_anchors = cfg.network.NUM_ANCHORS
+
+        # input init
+        if is_train:
+            data = mx.sym.Variable(name="data")
+            im_info = mx.sym.Variable(name="im_info")
+            gt_boxes = mx.sym.Variable(name="gt_boxes")
+            rpn_label = mx.sym.Variable(name='label')
+            rpn_bbox_target = mx.sym.Variable(name='bbox_target')
+            rpn_bbox_weight = mx.sym.Variable(name='bbox_weight')
+        else:
+            data = mx.sym.Variable(name="data")
+            im_info = mx.sym.Variable(name="im_info")
+
+        # shared convolutional layers
+        conv_feat = self.get_resnet_v1_conv4(data)
+        # res5
+        relu1, res5a_branch2b_offset, res5b_branch2b_offset, res5c_branch2b_offset = self.get_resnet_v1_conv5(conv_feat)
+
+        rpn_cls_score, rpn_bbox_pred = self.get_rpn(conv_feat, num_anchors)
+
+        if is_train:
+            # prepare rpn data
+            rpn_cls_score_reshape = mx.sym.Reshape(
+                data=rpn_cls_score, shape=(0, 2, -1, 0), name="rpn_cls_score_reshape")
+
+            # classification
+            rpn_cls_prob = mx.sym.SoftmaxOutput(data=rpn_cls_score_reshape, label=rpn_label, multi_output=True,
+                                                normalization='valid', use_ignore=True, ignore_label=-1, name="rpn_cls_prob")
+            # bounding box regression
+            rpn_bbox_loss_ = rpn_bbox_weight * mx.sym.smooth_l1(name='rpn_bbox_loss_', scalar=3.0, data=(rpn_bbox_pred - rpn_bbox_target))
+            rpn_bbox_loss = mx.sym.MakeLoss(name='rpn_bbox_loss', data=rpn_bbox_loss_, grad_scale=1.0 / cfg.TRAIN.RPN_BATCH_SIZE)
+
+            # ROI proposal
+            rpn_cls_act = mx.sym.SoftmaxActivation(
+                data=rpn_cls_score_reshape, mode="channel", name="rpn_cls_act")
+            rpn_cls_act_reshape = mx.sym.Reshape(
+                data=rpn_cls_act, shape=(0, 2 * num_anchors, -1, 0), name='rpn_cls_act_reshape')
+            if cfg.TRAIN.CXX_PROPOSAL:
+                rois = mx.contrib.sym.Proposal(
+                    cls_prob=rpn_cls_act_reshape, bbox_pred=rpn_bbox_pred, im_info=im_info, name='rois',
+                    feature_stride=cfg.network.RPN_FEAT_STRIDE, scales=tuple(cfg.network.ANCHOR_SCALES), ratios=tuple(cfg.network.ANCHOR_RATIOS),
+                    rpn_pre_nms_top_n=cfg.TRAIN.RPN_PRE_NMS_TOP_N, rpn_post_nms_top_n=cfg.TRAIN.RPN_POST_NMS_TOP_N,
+                    threshold=cfg.TRAIN.RPN_NMS_THRESH, rpn_min_size=cfg.TRAIN.RPN_MIN_SIZE)
+            else:
+                rois = mx.sym.Custom(
+                    cls_prob=rpn_cls_act_reshape, bbox_pred=rpn_bbox_pred, im_info=im_info, name='rois',
+                    op_type='proposal', feat_stride=cfg.network.RPN_FEAT_STRIDE,
+                    scales=tuple(cfg.network.ANCHOR_SCALES), ratios=tuple(cfg.network.ANCHOR_RATIOS),
+                    rpn_pre_nms_top_n=cfg.TRAIN.RPN_PRE_NMS_TOP_N, rpn_post_nms_top_n=cfg.TRAIN.RPN_POST_NMS_TOP_N,
+                    threshold=cfg.TRAIN.RPN_NMS_THRESH, rpn_min_size=cfg.TRAIN.RPN_MIN_SIZE)
+            # ROI proposal target
+            gt_boxes_reshape = mx.sym.Reshape(data=gt_boxes, shape=(-1, 5), name='gt_boxes_reshape')
+            rois, label, bbox_target, bbox_weight = mx.sym.Custom(rois=rois, gt_boxes=gt_boxes_reshape,
+                                                                  op_type='proposal_target',
+                                                                  num_classes=num_reg_classes,
+                                                                  batch_images=cfg.TRAIN.BATCH_IMAGES,
+                                                                  batch_rois=cfg.TRAIN.BATCH_ROIS,
+                                                                  cfg=cPickle.dumps(cfg),
+                                                                  fg_fraction=cfg.TRAIN.FG_FRACTION)
+        else:
+            # ROI Proposal
+            rpn_cls_score_reshape = mx.sym.Reshape(
+                data=rpn_cls_score, shape=(0, 2, -1, 0), name="rpn_cls_score_reshape")
+            rpn_cls_prob = mx.sym.SoftmaxActivation(
+                data=rpn_cls_score_reshape, mode="channel", name="rpn_cls_prob")
+            rpn_cls_prob_reshape = mx.sym.Reshape(
+                data=rpn_cls_prob, shape=(0, 2 * num_anchors, -1, 0), name='rpn_cls_prob_reshape')
+            if cfg.TEST.CXX_PROPOSAL:
+                rois = mx.contrib.sym.Proposal(
+                    cls_prob=rpn_cls_prob_reshape, bbox_pred=rpn_bbox_pred, im_info=im_info, name='rois',
+                    feature_stride=cfg.network.RPN_FEAT_STRIDE, scales=tuple(cfg.network.ANCHOR_SCALES),
+                    ratios=tuple(cfg.network.ANCHOR_RATIOS),
+                    rpn_pre_nms_top_n=cfg.TEST.RPN_PRE_NMS_TOP_N, rpn_post_nms_top_n=cfg.TEST.RPN_POST_NMS_TOP_N,
+                    threshold=cfg.TEST.RPN_NMS_THRESH, rpn_min_size=cfg.TEST.RPN_MIN_SIZE)
+            else:
+                rois = mx.sym.Custom(
+                    cls_prob=rpn_cls_prob_reshape, bbox_pred=rpn_bbox_pred, im_info=im_info, name='rois',
+                    op_type='proposal', feat_stride=cfg.network.RPN_FEAT_STRIDE,
+                    scales=tuple(cfg.network.ANCHOR_SCALES), ratios=tuple(cfg.network.ANCHOR_RATIOS),
+                    rpn_pre_nms_top_n=cfg.TEST.RPN_PRE_NMS_TOP_N, rpn_post_nms_top_n=cfg.TEST.RPN_POST_NMS_TOP_N,
+                    threshold=cfg.TEST.RPN_NMS_THRESH, rpn_min_size=cfg.TEST.RPN_MIN_SIZE)
+
+
+
+        # conv_new_1
+        conv_new_1 = mx.sym.Convolution(data=relu1, kernel=(1, 1), num_filter=1024, name="conv_new_1", lr_mult=3.0)
+        relu_new_1 = mx.sym.Activation(data=conv_new_1, act_type='relu', name='relu1')
+
+        # rfcn_cls/rfcn_bbox
+        rfcn_cls = mx.sym.Convolution(data=relu_new_1, kernel=(1, 1), num_filter=7*7*num_classes, name="rfcn_cls")
+        rfcn_bbox = mx.sym.Convolution(data=relu_new_1, kernel=(1, 1), num_filter=7*7*4*num_reg_classes, name="rfcn_bbox")
+        # trans_cls / trans_cls
+        rfcn_cls_offset_t = mx.sym.Convolution(data=relu_new_1, kernel=(1, 1), num_filter=2 * 7 * 7 * num_classes, name="rfcn_cls_offset_t")
+        rfcn_bbox_offset_t = mx.sym.Convolution(data=relu_new_1, kernel=(1, 1), num_filter=7 * 7 * 2, name="rfcn_bbox_offset_t")
+
+        rfcn_cls_offset = mx.contrib.sym.DeformablePSROIPooling(name='rfcn_cls_offset', data=rfcn_cls_offset_t, rois=rois, group_size=7, pooled_size=7,
+                                                                sample_per_part=4, no_trans=True, part_size=7, output_dim=2 * num_classes, spatial_scale=0.0625)
+        rfcn_bbox_offset = mx.contrib.sym.DeformablePSROIPooling(name='rfcn_bbox_offset', data=rfcn_bbox_offset_t, rois=rois, group_size=7, pooled_size=7,
+                                                                 sample_per_part=4, no_trans=True, part_size=7, output_dim=2, spatial_scale=0.0625)
+
+        psroipooled_cls_rois = mx.contrib.sym.DeformablePSROIPooling(name='psroipooled_cls_rois', data=rfcn_cls, rois=rois, trans=rfcn_cls_offset,
+                                                                     group_size=7, pooled_size=7, sample_per_part=4, no_trans=False, trans_std=0.1,
+                                                                     output_dim=num_classes, spatial_scale=0.0625, part_size=7)
+        psroipooled_loc_rois = mx.contrib.sym.DeformablePSROIPooling(name='psroipooled_loc_rois', data=rfcn_bbox, rois=rois, trans=rfcn_bbox_offset,
+                                                                     group_size=7, pooled_size=7, sample_per_part=4, no_trans=False, trans_std=0.1,
+                                                                     output_dim=8, spatial_scale=0.0625, part_size=7)
+        cls_score = mx.sym.Pooling(name='ave_cls_scors_rois', data=psroipooled_cls_rois, pool_type='avg', global_pool=True, kernel=(7, 7))
+        bbox_pred = mx.sym.Pooling(name='ave_bbox_pred_rois', data=psroipooled_loc_rois, pool_type='avg', global_pool=True, kernel=(7, 7))
+        cls_score = mx.sym.Reshape(name='cls_score_reshape', data=cls_score, shape=(-1, num_classes))
+        bbox_pred = mx.sym.Reshape(name='bbox_pred_reshape', data=bbox_pred, shape=(-1, 4 * num_reg_classes))
+
+        if is_train:
+            if cfg.TRAIN.ENABLE_OHEM:
+                labels_ohem, bbox_weights_ohem = mx.sym.Custom(op_type='BoxAnnotatorOHEM', num_classes=num_classes,
+                                                               num_reg_classes=num_reg_classes, roi_per_img=cfg.TRAIN.BATCH_ROIS_OHEM,
+                                                               cls_score=cls_score, bbox_pred=bbox_pred, labels=label,
+                                                               bbox_targets=bbox_target, bbox_weights=bbox_weight)
+                cls_prob = mx.sym.SoftmaxOutput(name='cls_prob', data=cls_score, label=labels_ohem, normalization='valid', use_ignore=True, ignore_label=-1)
+                bbox_loss_ = bbox_weights_ohem * mx.sym.smooth_l1(name='bbox_loss_', scalar=1.0, data=(bbox_pred - bbox_target))
+                bbox_loss = mx.sym.MakeLoss(name='bbox_loss', data=bbox_loss_, grad_scale=1.0 / cfg.TRAIN.BATCH_ROIS_OHEM)
+                rcnn_label = labels_ohem
+            else:
+                cls_prob = mx.sym.SoftmaxOutput(name='cls_prob', data=cls_score, label=label, normalization='valid')
+                bbox_loss_ = bbox_weight * mx.sym.smooth_l1(name='bbox_loss_', scalar=1.0, data=(bbox_pred - bbox_target))
+                bbox_loss = mx.sym.MakeLoss(name='bbox_loss', data=bbox_loss_, grad_scale=1.0 / cfg.TRAIN.BATCH_ROIS)
+                rcnn_label = label
+
+            # reshape output
+            rcnn_label = mx.sym.Reshape(data=rcnn_label, shape=(cfg.TRAIN.BATCH_IMAGES, -1), name='label_reshape')
+            cls_prob = mx.sym.Reshape(data=cls_prob, shape=(cfg.TRAIN.BATCH_IMAGES, -1, num_classes), name='cls_prob_reshape')
+            bbox_loss = mx.sym.Reshape(data=bbox_loss, shape=(cfg.TRAIN.BATCH_IMAGES, -1, 4 * num_reg_classes), name='bbox_loss_reshape')
+            group = mx.sym.Group([rpn_cls_prob, rpn_bbox_loss, cls_prob, bbox_loss, mx.sym.BlockGrad(rcnn_label)])
+        else:
+            cls_prob = mx.sym.SoftmaxActivation(name='cls_prob', data=cls_score)
+            cls_prob = mx.sym.Reshape(data=cls_prob, shape=(cfg.TEST.BATCH_IMAGES, -1, num_classes),
+                                      name='cls_prob_reshape')
+            bbox_pred = mx.sym.Reshape(data=bbox_pred, shape=(cfg.TEST.BATCH_IMAGES, -1, 4 * num_reg_classes),
+                                       name='bbox_pred_reshape')
+            group = mx.sym.Group([rois, cls_prob, bbox_pred, res5a_branch2b_offset, res5b_branch2b_offset, res5c_branch2b_offset])
+
+        self.sym = group
+        return group
+
+    def get_symbol_rpn(self, cfg, is_train=True):
+        # config alias for convenient
+        num_anchors = cfg.network.NUM_ANCHORS
+
+        # input init
+        if is_train:
+            data = mx.sym.Variable(name="data")
+            rpn_label = mx.sym.Variable(name='label')
+            rpn_bbox_target = mx.sym.Variable(name='bbox_target')
+            rpn_bbox_weight = mx.sym.Variable(name='bbox_weight')
+        else:
+            data = mx.sym.Variable(name="data")
+            im_info = mx.sym.Variable(name="im_info")
+
+        # shared convolutional layers
+        conv_feat = self.get_resnet_v1_conv4(data)
+        rpn_cls_score, rpn_bbox_pred = self.get_rpn(conv_feat, num_anchors)
+        if is_train:
+            # prepare rpn data
+            rpn_cls_score_reshape = mx.sym.Reshape(
+                data=rpn_cls_score, shape=(0, 2, -1, 0), name="rpn_cls_score_reshape")
+
+            # classification
+            rpn_cls_prob = mx.sym.SoftmaxOutput(data=rpn_cls_score_reshape, label=rpn_label, multi_output=True,
+                                                normalization='valid', use_ignore=True, ignore_label=-1, name="rpn_cls_prob",
+                                                grad_scale=1.0)
+            # bounding box regression
+            rpn_bbox_loss_ = rpn_bbox_weight * mx.sym.smooth_l1(name='rpn_bbox_loss_', scalar=3.0, data=(rpn_bbox_pred - rpn_bbox_target))
+            rpn_bbox_loss = mx.sym.MakeLoss(name='rpn_bbox_loss', data=rpn_bbox_loss_, grad_scale=1.0 / cfg.TRAIN.RPN_BATCH_SIZE)
+            group = mx.symbol.Group([rpn_cls_prob, rpn_bbox_loss])
+        else:
+            # ROI Proposal
+            rpn_cls_score_reshape = mx.sym.Reshape(
+                data=rpn_cls_score, shape=(0, 2, -1, 0), name="rpn_cls_score_reshape")
+            rpn_cls_prob = mx.sym.SoftmaxActivation(
+                data=rpn_cls_score_reshape, mode="channel", name="rpn_cls_prob")
+            rpn_cls_prob_reshape = mx.sym.Reshape(
+                data=rpn_cls_prob, shape=(0, 2 * num_anchors, -1, 0), name='rpn_cls_prob_reshape')
+            if cfg.TEST.CXX_PROPOSAL:
+                rois, score = mx.contrib.sym.Proposal(
+                    cls_prob=rpn_cls_prob_reshape, bbox_pred=rpn_bbox_pred, im_info=im_info, name='rois', output_score=True,
+                    feature_stride=cfg.network.RPN_FEAT_STRIDE, scales=tuple(cfg.network.ANCHOR_SCALES),
+                    ratios=tuple(cfg.network.ANCHOR_RATIOS),
+                    rpn_pre_nms_top_n=cfg.TEST.RPN_PRE_NMS_TOP_N, rpn_post_nms_top_n=cfg.TEST.RPN_POST_NMS_TOP_N,
+                    threshold=cfg.TEST.RPN_NMS_THRESH, rpn_min_size=cfg.TEST.RPN_MIN_SIZE)
+            else:
+                rois, score = mx.sym.Custom(
+                    cls_prob=rpn_cls_prob_reshape, bbox_pred=rpn_bbox_pred, im_info=im_info, name='rois', output_score=True,
+                    op_type='proposal', feat_stride=cfg.network.RPN_FEAT_STRIDE,
+                    scales=tuple(cfg.network.ANCHOR_SCALES), ratios=tuple(cfg.network.ANCHOR_RATIOS),
+                    rpn_pre_nms_top_n=cfg.TEST.RPN_PRE_NMS_TOP_N, rpn_post_nms_top_n=cfg.TEST.RPN_POST_NMS_TOP_N,
+                    threshold=cfg.TEST.RPN_NMS_THRESH, rpn_min_size=cfg.TEST.RPN_MIN_SIZE)
+                group = mx.symbol.Group([rois, score])
+        self.sym = group
+        return group
+
+    def get_symbol_rfcn(self, cfg, is_train=True):
+
+        # config alias for convenient
+        num_classes = cfg.dataset.NUM_CLASSES
+        num_reg_classes = (2 if cfg.CLASS_AGNOSTIC else num_classes)
+
+        # input init
+        if is_train:
+            data = mx.symbol.Variable(name="data")
+            rois = mx.symbol.Variable(name='rois')
+            label = mx.symbol.Variable(name='label')
+            bbox_target = mx.symbol.Variable(name='bbox_target')
+            bbox_weight = mx.symbol.Variable(name='bbox_weight')
+            # reshape input
+            rois = mx.symbol.Reshape(data=rois, shape=(-1, 5), name='rois_reshape')
+            label = mx.symbol.Reshape(data=label, shape=(-1,), name='label_reshape')
+            bbox_target = mx.symbol.Reshape(data=bbox_target, shape=(-1, 4 * num_reg_classes), name='bbox_target_reshape')
+            bbox_weight = mx.symbol.Reshape(data=bbox_weight, shape=(-1, 4 * num_reg_classes), name='bbox_weight_reshape')
+        else:
+            data = mx.sym.Variable(name="data")
+            rois = mx.symbol.Variable(name='rois')
+            # reshape input
+            rois = mx.symbol.Reshape(data=rois, shape=(-1, 5), name='rois_reshape')
+
+        # shared convolutional layers
+        conv_feat = self.get_resnet_v1_conv4(data)
+        relu1 = self.get_resnet_v1_conv5(conv_feat)
+
+        # conv_new_1
+        conv_new_1 = mx.sym.Convolution(data=relu1, kernel=(1, 1), num_filter=1024, name="conv_new_1", lr_mult=3.0)
+        relu_new_1 = mx.sym.Activation(data=conv_new_1, act_type='relu', name='relu1')
+
+        # rfcn_cls/rfcn_bbox
+        rfcn_cls = mx.sym.Convolution(data=relu_new_1, kernel=(1, 1), num_filter=7*7*num_classes, name="rfcn_cls")
+        rfcn_bbox = mx.sym.Convolution(data=relu_new_1, kernel=(1, 1), num_filter=7*7*4*num_reg_classes, name="rfcn_bbox")
+        # trans_cls / trans_cls
+        rfcn_cls_offset_t = mx.sym.Convolution(data=relu_new_1, kernel=(1, 1), num_filter=2 * 7 * 7 * num_classes, name="rfcn_cls_offset_t")
+        rfcn_bbox_offset_t = mx.sym.Convolution(data=relu_new_1, kernel=(1, 1), num_filter=7 * 7 * 2, name="rfcn_bbox_offset_t")
+
+        rfcn_cls_offset = mx.contrib.sym.DeformablePSROIPooling(name='rfcn_cls_offset', data=rfcn_cls_offset_t, rois=rois, group_size=7, pooled_size=7,
+                                                                sample_per_part=4, no_trans=True, part_size=7, output_dim=2 * num_classes, spatial_scale=0.0625)
+        rfcn_bbox_offset = mx.contrib.sym.DeformablePSROIPooling(name='rfcn_bbox_offset', data=rfcn_bbox_offset_t, rois=rois, group_size=7, pooled_size=7,
+                                                                 sample_per_part=4, no_trans=True, part_size=7, output_dim=2, spatial_scale=0.0625)
+
+        psroipooled_cls_rois = mx.contrib.sym.DeformablePSROIPooling(name='psroipooled_cls_rois', data=rfcn_cls, rois=rois, trans=rfcn_cls_offset,
+                                                                     group_size=7, pooled_size=7, sample_per_part=4, no_trans=False, trans_std=0.1,
+                                                                     output_dim=num_classes, spatial_scale=0.0625, part_size=7)
+        psroipooled_loc_rois = mx.contrib.sym.DeformablePSROIPooling(name='psroipooled_loc_rois', data=rfcn_bbox, rois=rois, trans=rfcn_bbox_offset,
+                                                                     group_size=7, pooled_size=7, sample_per_part=4, no_trans=False, trans_std=0.1,
+                                                                     output_dim=8, spatial_scale=0.0625, part_size=7)
+        cls_score = mx.sym.Pooling(name='ave_cls_scors_rois', data=psroipooled_cls_rois, pool_type='avg', global_pool=True, kernel=(7, 7))
+        bbox_pred = mx.sym.Pooling(name='ave_bbox_pred_rois', data=psroipooled_loc_rois, pool_type='avg', global_pool=True, kernel=(7, 7))
+        cls_score = mx.sym.Reshape(name='cls_score_reshape', data=cls_score, shape=(-1, num_classes))
+        bbox_pred = mx.sym.Reshape(name='bbox_pred_reshape', data=bbox_pred, shape=(-1, 4 * num_reg_classes))
+
+        if is_train:
+            if cfg.TRAIN.ENABLE_OHEM:
+                labels_ohem, bbox_weights_ohem = mx.sym.Custom(op_type='BoxAnnotatorOHEM', num_classes=num_classes,
+                                                               num_reg_classes=num_reg_classes, roi_per_img=cfg.TRAIN.BATCH_ROIS_OHEM,
+                                                               cls_score=cls_score, bbox_pred=bbox_pred, labels=label,
+                                                               bbox_targets=bbox_target, bbox_weights=bbox_weight)
+                cls_prob = mx.sym.SoftmaxOutput(name='cls_prob', data=cls_score, label=labels_ohem, normalization='valid', use_ignore=True, ignore_label=-1, grad_scale=1.0)
+                bbox_loss_ = bbox_weights_ohem * mx.sym.smooth_l1(name='bbox_loss_', scalar=1.0, data=(bbox_pred - bbox_target))
+                bbox_loss = mx.sym.MakeLoss(name='bbox_loss', data=bbox_loss_, grad_scale=1.0 / cfg.TRAIN.BATCH_ROIS_OHEM)
+                label = labels_ohem
+            else:
+                cls_prob = mx.sym.SoftmaxOutput(name='cls_prob', data=cls_score, label=label, normalization='valid', grad_scale=1.0)
+                bbox_loss_ = bbox_weight * mx.sym.smooth_l1(name='bbox_loss_', scalar=1.0, data=(bbox_pred - bbox_target))
+                bbox_loss = mx.sym.MakeLoss(name='bbox_loss', data=bbox_loss_, grad_scale=1.0 / cfg.TRAIN.BATCH_ROIS)
+
+            # reshape output
+            cls_prob = mx.sym.Reshape(data=cls_prob, shape=(cfg.TRAIN.BATCH_IMAGES, -1, num_classes), name='cls_prob_reshape')
+            bbox_loss = mx.sym.Reshape(data=bbox_loss, shape=(cfg.TRAIN.BATCH_IMAGES, -1, 4 * num_reg_classes), name='bbox_loss_reshape')
+            group = mx.sym.Group([cls_prob, bbox_loss, mx.sym.BlockGrad(label)]) if cfg.TRAIN.ENABLE_OHEM else mx.sym.Group([cls_prob, bbox_loss])
+        else:
+            cls_prob = mx.sym.SoftmaxActivation(name='cls_prob', data=cls_score)
+            cls_prob = mx.sym.Reshape(data=cls_prob, shape=(cfg.TEST.BATCH_IMAGES, -1, num_classes),
+                                      name='cls_prob_reshape')
+            bbox_pred = mx.sym.Reshape(data=bbox_pred, shape=(cfg.TEST.BATCH_IMAGES, -1, 4 * num_reg_classes),
+                                       name='bbox_pred_reshape')
+            group = mx.sym.Group([cls_prob, bbox_pred])
+
+        self.sym = group
+        return group
+
+    def init_weight_rpn(self, cfg, arg_params, aux_params):
+        arg_params['rpn_conv_3x3_weight'] = mx.random.normal(0, 0.01, shape=self.arg_shape_dict['rpn_conv_3x3_weight'])
+        arg_params['rpn_conv_3x3_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['rpn_conv_3x3_bias'])
+        arg_params['rpn_cls_score_weight'] = mx.random.normal(0, 0.01, shape=self.arg_shape_dict['rpn_cls_score_weight'])
+        arg_params['rpn_cls_score_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['rpn_cls_score_bias'])
+        arg_params['rpn_bbox_pred_weight'] = mx.random.normal(0, 0.01, shape=self.arg_shape_dict['rpn_bbox_pred_weight'])
+        arg_params['rpn_bbox_pred_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['rpn_bbox_pred_bias'])
+
+    def init_weight_rfcn(self, cfg, arg_params, aux_params):
+        arg_params['res5a_branch2b_offset_weight'] = mx.nd.zeros(shape=self.arg_shape_dict['res5a_branch2b_offset_weight'])
+        arg_params['res5a_branch2b_offset_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['res5a_branch2b_offset_bias'])
+        arg_params['res5b_branch2b_offset_weight'] = mx.nd.zeros(shape=self.arg_shape_dict['res5b_branch2b_offset_weight'])
+        arg_params['res5b_branch2b_offset_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['res5b_branch2b_offset_bias'])
+        arg_params['res5c_branch2b_offset_weight'] = mx.nd.zeros(shape=self.arg_shape_dict['res5c_branch2b_offset_weight'])
+        arg_params['res5c_branch2b_offset_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['res5c_branch2b_offset_bias'])
+        arg_params['conv_new_1_weight'] = mx.random.normal(0, 0.01, shape=self.arg_shape_dict['conv_new_1_weight'])
+        arg_params['conv_new_1_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['conv_new_1_bias'])
+        arg_params['rfcn_cls_weight'] = mx.random.normal(0, 0.01, shape=self.arg_shape_dict['rfcn_cls_weight'])
+        arg_params['rfcn_cls_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['rfcn_cls_bias'])
+        arg_params['rfcn_bbox_weight'] = mx.random.normal(0, 0.01, shape=self.arg_shape_dict['rfcn_bbox_weight'])
+        arg_params['rfcn_bbox_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['rfcn_bbox_bias'])
+        arg_params['rfcn_cls_offset_t_weight'] = mx.nd.zeros(shape=self.arg_shape_dict['rfcn_cls_offset_t_weight'])
+        arg_params['rfcn_cls_offset_t_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['rfcn_cls_offset_t_bias'])
+        arg_params['rfcn_bbox_offset_t_weight'] = mx.nd.zeros(shape=self.arg_shape_dict['rfcn_bbox_offset_t_weight'])
+        arg_params['rfcn_bbox_offset_t_bias'] = mx.nd.zeros(shape=self.arg_shape_dict['rfcn_bbox_offset_t_bias'])
+
+    def init_weight(self, cfg, arg_params, aux_params):
+        self.init_weight_rpn(cfg, arg_params, aux_params)
+        self.init_weight_rfcn(cfg, arg_params, aux_params)
+


### PR DESCRIPTION
Added a new model for Faster R-CNN which I call as dense as the model contains skip connections from each of the blocks from ResNet for feeding into the final classification head.
The availability of low-level features along with the more abstract features might result in an improvement in the overall classification performance of the system.
This approach has been tested for two of the tasks that I have been working on and has produced better results as compared to the original ResNet-101 model.